### PR TITLE
[TB-8] Auth 커스텀 어노테이션 생성

### DIFF
--- a/src/main/java/com/ClubAccount_BE/auth/security/JwtAuthenticationProvider.java
+++ b/src/main/java/com/ClubAccount_BE/auth/security/JwtAuthenticationProvider.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         User user = findUserUseCase.getUserByAuthId(String.valueOf(authenticationToken.getPrincipal()));
         String userPassword = String.valueOf(authenticationToken.getCredentials());
         if(!user.matchPassword(passwordEncoder, userPassword)) {
-            throw new UnAuthorizedException(INCORRECT_PASSWORD.toString());
+            throw new UnAuthorizedException(INCORRECT_PASSWORD);
         }
         return new JwtAuthenticationToken(
                 user.getId(), null, Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.ClubAccount_BE.core.config;
+
+import com.ClubAccount_BE.core.config.auth.LoginUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
@@ -28,14 +28,16 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {
-             throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
+            throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
         }
 
         String authId = authentication.getName();

--- a/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.ClubAccount_BE.core.config.auth;
+
+import com.ClubAccount_BE.core.exception.ErrorCode;
+import com.ClubAccount_BE.core.exception.UnAuthorizedException;
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.user.application.port.in.FindUserUseCase;
+import com.ClubAccount_BE.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final FindUserUseCase findUserUseCase;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUser.class) &&
+                parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+             throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String authId = authentication.getName();
+        return findUserUseCase.getUserByAuthId(authId);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     AUTHENTICATION_FAIL_FORBIDDEN("AUTH_403_FORBIDDEN", "접근 권한이 없습니다."),
     AUTHENTICATION_FAIL_UNAUTHORIZED("AUTH_401_UNAUTHORIZED", "인증되지 않은 사용자입니다."),
     INCORRECT_PASSWORD("AUTH_401_INCORRECT_PASSWORD", "비밀번호가 일치하지 않습니다."),
-    DUPLICATED_AUTHID("AUTH_400_DUPLICATED_AUTHID", "이미 존재하는 아이디입니다.");
+    DUPLICATED_AUTHID("AUTH_400_DUPLICATED_AUTHID", "이미 존재하는 아이디입니다."),
+    UNAUTHORIZED("A001", "인증이 필요합니다.");
     private final String code;
     private final String message;
 

--- a/src/main/java/com/ClubAccount_BE/core/exception/UnAuthorizedException.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/UnAuthorizedException.java
@@ -1,7 +1,13 @@
 package com.ClubAccount_BE.core.exception;
 
+import lombok.Getter;
+
+@Getter
 public class UnAuthorizedException extends RuntimeException{
-    public UnAuthorizedException(String message) {
-        super(message);
+    private final ErrorCode errorCode;
+
+    public UnAuthorizedException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/ClubAccount_BE/core/meta/LoginUser.java
+++ b/src/main/java/com/ClubAccount_BE/core/meta/LoginUser.java
@@ -1,0 +1,15 @@
+package com.ClubAccount_BE.core.meta;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LoginUser {
+
+}
+


### PR DESCRIPTION
## 📌 작업 개요
* 컨트롤러에서 현재 로그인한 사용자를 쉽게 주입받을 수 있도록 @LoginUser 커스텀 어노테이션 구현

---

## ✅ 작업 내용
	1.	@LoginUser 커스텀 파라미터 어노테이션 정의
	2.	LoginUserArgumentResolver 구현 및 WebMvcConfigurer 등록
	3.	인증되지 않은 사용자 요청 시 UnAuthorizedException을 통해 401 예외 반환
	4.	FindUserUseCase를 통해 authId 기반 유저 조회 로직 분리

---

