### PR TITLE
[TB-11] 인증 유저 조회 방식 변경 

### DIFF
--- a/src/main/java/com/ClubAccount_BE/core/config/SwaggerConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/SwaggerConfig.java
@@ -4,8 +4,21 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 
 @Configuration
+@SecurityScheme(
+    name = "JWT TOKEN",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT"
+)
+@OpenAPIDefinition(
+    security = @SecurityRequirement(name = "JWT TOKEN")
+)
 public class SwaggerConfig {
 
     @Bean

--- a/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
@@ -44,7 +44,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
         }
 
-        Long authId = Long.valueOf(authentication.getName());
-        return findUserUseCase.getUserById(authId);
+        Long userId = Long.valueOf(authentication.getName());
+        return findUserUseCase.getUserById(userId);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
@@ -40,7 +40,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             throw new UnAuthorizedException(ErrorCode.UNAUTHORIZED);
         }
 
-        String authId = authentication.getName();
-        return findUserUseCase.getUserByAuthId(authId);
+        Long authId = Long.valueOf(authentication.getName());
+        return findUserUseCase.getUserById(authId);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolver.java
@@ -34,6 +34,10 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) {
+        return getAuthenticatedUser();
+    }
+
+    private User getAuthenticatedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (authentication == null || !authentication.isAuthenticated()) {

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -32,6 +32,14 @@ public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, Check
     }
 
     @Override
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .map(userMapper::toDomain)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 사용자를 찾을 수 없습니다."));
+    }
+
+
+    @Override
     public boolean checkDuplicateAuthId(String authId) {
         return userRepository.existsByAuthId(authId);
     }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
@@ -9,8 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
-
     Optional<UserEntity> getByAuthId(String authId);
-
+    Optional<UserEntity> findById(Long userId);
     boolean existsByAuthId(String authId);
+
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/FindUserUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/FindUserUseCase.java
@@ -3,5 +3,6 @@ package com.ClubAccount_BE.user.application.port.in;
 import com.ClubAccount_BE.user.domain.User;
 
 public interface FindUserUseCase {
+    User getUserById(Long userId);
     User getUserByAuthId(String email);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/FindUserPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/FindUserPort.java
@@ -4,4 +4,6 @@ import com.ClubAccount_BE.user.domain.User;
 
 public interface FindUserPort {
     User getUserByAuthId(String email);
+
+    User getUserById(Long userId);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/service/FindUserService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/FindUserService.java
@@ -15,6 +15,11 @@ public class FindUserService implements FindUserUseCase {
     private final FindUserPort findUserPort;
 
     @Override
+    public User getUserById(Long userId) {
+        return findUserPort.getUserById(userId);
+    }
+
+    @Override
     public User getUserByAuthId(String authId) {
         return findUserPort.getUserByAuthId(authId);
     }

--- a/src/test/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/ClubAccount_BE/core/config/auth/LoginUserArgumentResolverTest.java
@@ -1,0 +1,74 @@
+package com.ClubAccount_BE.core.config.auth;
+
+import com.ClubAccount_BE.core.exception.UnAuthorizedException;
+import com.ClubAccount_BE.user.application.port.in.FindUserUseCase;
+import com.ClubAccount_BE.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LoginUserArgumentResolverTest {
+
+    @Mock
+    private FindUserUseCase findUserUseCase;
+
+    @InjectMocks
+    private LoginUserArgumentResolver resolver;
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @Mock
+    private WebDataBinderFactory binderFactory;
+
+    @Test
+    void 인증_정보가_없으면_예외발생() {
+        // given
+        SecurityContextHolder.clearContext(); // 인증 정보 없음
+
+        // when & then
+        assertThrows(UnAuthorizedException.class, () -> {
+            resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+        });
+    }
+
+    @Test
+    void 인증_정보가_있으면_User_반환(){
+        // given
+        Long authId = 1L;
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(authentication.getName()).thenReturn(authId.toString());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        User mockUser = User.builder().id(authId).build();
+        when(findUserUseCase.getUserById(authId)).thenReturn(mockUser);
+
+        // when
+        Object result = resolver.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+        // then
+        assertThat(result).isEqualTo(mockUser);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
* 	인증 유저 조회 방식 변경 (authId → userId)

---

## ✅ 작업 내용
	1.	LoginUserArgumentResolver에서 getUserByAuthId() → getUserById()로 변경(식별자 기반)
	2.	내부 식별자 기반 유저 조회 로직 적용
	3.      Swagger UI에 JWT 인증 기능 추가

---


