### PR TITLE
[TB-12] 리프레시 토큰을 http only cookie로 전달

### DIFF
--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInApiPresentation.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInApiPresentation.java
@@ -6,11 +6,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletResponse;
 
-    @Tag(name = "SignIn", description = "로그인 API")
-    public interface SignInApiPresentation {
+@Tag(name = "SignIn", description = "로그인 API")
+public interface SignInApiPresentation {
 
-        @Operation(summary = "로그인")
-        TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest);
+    @Operation(summary = "로그인")
+    TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest, HttpServletResponse response);
 
 }

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import java.time.Duration;
 
 @RestController
 @RequestMapping("api/v1/auth")
@@ -18,7 +22,19 @@ public class SignInController implements SignInApiPresentation{
     private final SignInUseCase signInUseCase;
 
     @PostMapping("/sign-in")
-    public TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest) {
-        return signInUseCase.signIn(signInRequest.getAuthId(), signInRequest.getPassword());
+    public TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest, HttpServletResponse response) {
+        TokenResponse tokenResponse = signInUseCase.signIn(signInRequest.getAuthId(), signInRequest.getPassword());
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenResponse.getRefreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return TokenResponse.from(tokenResponse.getAccessToken());
     }
 }

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
@@ -30,7 +30,8 @@ public class SignInController implements SignInApiPresentation{
                 .secure(true)
                 .path("/")
                 .maxAge(Duration.ofDays(7))
-                .sameSite("Lax")
+                .sameSite("None")
+                .secure(true)
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/dto/response/TokenResponse.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/dto/response/TokenResponse.java
@@ -11,13 +11,21 @@ public class TokenResponse {
     @Schema(name = "accessToken", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
     private String accessToken;
 
-    @Schema(name = "refreshToken", example = "7f734e1b-669d-430e-ac78-270e3863db50")
+    @Schema(hidden = true)
     private String refreshToken;
 
     @Builder
-    private TokenResponse(String accessToken, String refreshToken) {
+    public TokenResponse(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+    }
+
+    public static TokenResponse from(String accessToken) {
+        return TokenResponse
+                .builder()
+                .accessToken(accessToken)
+                .refreshToken("")
+                .build();
     }
 
     public static TokenResponse from(String accessToken, String refreshToken) {
@@ -27,5 +35,4 @@ public class TokenResponse {
                 .refreshToken(refreshToken)
                 .build();
     }
-
 }

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenApiPresentation.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenApiPresentation.java
@@ -4,9 +4,11 @@ import com.ClubAccount_BE.auth.adapter.in.web.token.dto.request.TokenRequest;
 import com.ClubAccount_BE.auth.adapter.in.web.token.dto.response.AccessTokenResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Token", description = "토큰 발급 API")
 public interface TokenApiPresentation {
-    AccessTokenResponse createNewToken(@Valid @RequestBody TokenRequest tokenRequest);
+    AccessTokenResponse createNewToken(@Valid @RequestBody TokenRequest tokenRequest, HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
@@ -3,6 +3,8 @@ package com.ClubAccount_BE.auth.adapter.in.web.token;
 import com.ClubAccount_BE.auth.adapter.in.web.token.dto.request.TokenRequest;
 import com.ClubAccount_BE.auth.adapter.in.web.token.dto.response.AccessTokenResponse;
 import com.ClubAccount_BE.auth.application.port.in.TokenUseCase;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/v1/auth")
 @RequiredArgsConstructor
-public class TokenController implements TokenApiPresentation{
+public class TokenController implements TokenApiPresentation {
     private final TokenUseCase tokenUseCase;
 
     @PostMapping("/token")
-    public AccessTokenResponse createNewToken(@Valid @RequestBody TokenRequest tokenRequest) {
+    public AccessTokenResponse createNewToken(@Valid @RequestBody TokenRequest tokenRequest,
+                                              HttpServletRequest request,
+                                              HttpServletResponse response) {
         return tokenUseCase.createNewToken(tokenRequest.getRefreshToken());
     }
 

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
@@ -3,26 +3,28 @@ package com.ClubAccount_BE.auth.adapter.in.web.token;
 import com.ClubAccount_BE.auth.adapter.in.web.token.dto.request.TokenRequest;
 import com.ClubAccount_BE.auth.adapter.in.web.token.dto.response.AccessTokenResponse;
 import com.ClubAccount_BE.auth.application.port.in.TokenUseCase;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/auth")
 @RequiredArgsConstructor
 public class TokenController implements TokenApiPresentation {
+
     private final TokenUseCase tokenUseCase;
 
     @PostMapping("/token")
-    public AccessTokenResponse createNewToken(@Valid @RequestBody TokenRequest tokenRequest,
-                                              HttpServletRequest request,
-                                              HttpServletResponse response) {
+    public AccessTokenResponse createNewToken(
+            @Valid @RequestBody TokenRequest tokenRequest,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
         return tokenUseCase.createNewToken(tokenRequest.getRefreshToken());
     }
-
 }

--- a/src/main/java/com/ClubAccount_BE/auth/application/service/SignInService.java
+++ b/src/main/java/com/ClubAccount_BE/auth/application/service/SignInService.java
@@ -27,7 +27,7 @@ public class SignInService implements SignInUseCase {
         String accessToken = tokenProvider.generateToken(userId);
         String refreshToken = tokenProvider.generateRefreshToken();
         saveRefreshTokenPort.saveRefreshToken(refreshToken, userId);
-        return TokenResponse.from(accessToken, refreshToken);
+        return TokenResponse.from(accessToken);
     }
 
     private Authentication authenticateCommand(String authId, String password) {

--- a/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
@@ -1,21 +1,26 @@
 package com.ClubAccount_BE.core.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    AUTHENTICATION_FAIL_FORBIDDEN("AUTH_403_FORBIDDEN", "접근 권한이 없습니다."),
-    AUTHENTICATION_FAIL_UNAUTHORIZED("AUTH_401_UNAUTHORIZED", "인증되지 않은 사용자입니다."),
-    INCORRECT_PASSWORD("AUTH_401_INCORRECT_PASSWORD", "비밀번호가 일치하지 않습니다."),
-    DUPLICATED_AUTHID("AUTH_400_DUPLICATED_AUTHID", "이미 존재하는 아이디입니다."),
-    UNAUTHORIZED("A001", "인증이 필요합니다.");
+    AUTHENTICATION_FAIL_FORBIDDEN("AUTH_403_FORBIDDEN", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    AUTHENTICATION_FAIL_UNAUTHORIZED("AUTH_401_UNAUTHORIZED", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    INCORRECT_PASSWORD("AUTH_401_INCORRECT_PASSWORD", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    DUPLICATED_AUTHID("AUTH_400_DUPLICATED_AUTHID", "이미 존재하는 아이디입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("A001", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED);
+
     private final String code;
     private final String message;
+    private final HttpStatus httpStatus;
 
-    ErrorCode(String code, String message) {
+    ErrorCode(String code, String message, HttpStatus httpStatus) {
         this.code = code;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
+
     @Override
     public String toString() {
         return code;

--- a/src/main/java/com/ClubAccount_BE/core/exception/ExceptionResponse.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/ExceptionResponse.java
@@ -1,19 +1,25 @@
 package com.ClubAccount_BE.core.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class ExceptionResponse {
     private final String errorCode;
     private final String message;
+    private final HttpStatus httpStatus;
 
-
-    private ExceptionResponse(String errorCode, String message) {
+    private ExceptionResponse(String errorCode, String message, HttpStatus httpStatus) {
         this.errorCode = errorCode;
         this.message = message;
+        this.httpStatus = httpStatus;
     }
 
     public static ExceptionResponse from(ErrorCode errorCode) {
-        return new ExceptionResponse(errorCode.getCode(), errorCode.getMessage());
+        return new ExceptionResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errorCode.getHttpStatus()
+        );
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
@@ -25,7 +25,8 @@ public class SignUpController implements SignUpApiPresentation {
 
     @GetMapping(value = "/sign-up/check-duplicate-auth-id", produces = "application/json")
     public AuthIdDuplicationResponse checkAuthIdDuplication(
-            @RequestParam("auth-id") @Size(min = 6, message = "INVALIDATED_AUTHID_TYPE") String authId) {
+            @RequestParam("auth-id") @Size(min = 6, message = "INVALIDATED_AUTHID_TYPE") String authId
+    ) {
         return checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
@@ -25,7 +25,7 @@ public class SignUpController implements SignUpApiPresentation {
 
     @GetMapping(value = "/sign-up/check-duplicate-auth-id", produces = "application/json")
     public AuthIdDuplicationResponse checkAuthIdDuplication(
-            @RequestParam("auth-id") @Size(min = 6, max = 20, message = "INVALIDATED_AUTHID_TYPE") String authId) {
+            @RequestParam("auth-id") @Size(min = 6, message = "INVALIDATED_AUTHID_TYPE") String authId) {
         return checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
* 리프레시 토큰을 http only cookie로 전달

---

## ✅ 작업 내용
1.리프레시 토큰을 http only cookie로 전달
2.이메일 아이디 최대 글자 제한 삭제

---

