### PR TITLE
[TB-13] CORS 설정에서 credentials 사용 시 origin 명시(1)

### DIFF
--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.ClubAccount_BE.core.config.auth.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
@@ -16,5 +17,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -24,7 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowCredentials(true)
+                .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -24,6 +24,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowCredentials(true);
+                .allowCredentials(true)
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
* CORS 설정에서 credentials 사용 시 origin 명시

---

## ✅ 작업 내용
1. credentials 요청 시 Access-Control-Allow-Origin을 와일드카드에서  도메인으로 변경
2.  로컬 개발 환경에 맞춰 설정(프론트 배포하면 프론트 주소로 변경)

---


