### PR TITLE
[TB-13] CORS 설정에서 credentials 사용 시 origin 명시(3)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - TB-13
 
 jobs:
   deploy:

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - TB-13
 
 jobs:
   deploy:

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
@@ -24,16 +24,13 @@ public class SignInController implements SignInApiPresentation{
     @PostMapping("/sign-in")
     public TokenResponse signIn(@Valid @RequestBody SignInRequest signInRequest, HttpServletResponse response) {
         TokenResponse tokenResponse = signInUseCase.signIn(signInRequest.getAuthId(), signInRequest.getPassword());
-
         ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenResponse.getRefreshToken())
                 .httpOnly(true)
-                .secure(true)
                 .path("/")
                 .maxAge(Duration.ofDays(7))
                 .sameSite("None")
-                .secure(true)
+                .secure(false)
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return TokenResponse.from(tokenResponse.getAccessToken());

--- a/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,9 +16,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
@@ -64,28 +62,12 @@ public class SecurityConfig {
             .sessionManagement(sess -> sess
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
-            .cors(cors -> cors
-                .configurationSource(corsConfigurationSource())
-            )
+            .cors(Customizer.withDefaults())
             .addFilterBefore(tokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-
-        configuration.addAllowedOrigin("*");
-        configuration.addAllowedHeader("*");
-        configuration.addAllowedMethod("*");
-        configuration.setAllowCredentials(false);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-
-        return source;
-    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.ClubAccount_BE.core.config.auth.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
@@ -16,5 +17,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -24,7 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowCredentials(true)
+                .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -25,6 +25,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
+                .exposedHeaders("Authorization", "Set-Cookie")
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -24,6 +24,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowCredentials(true);
+                .allowCredentials(true)
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
* SecurityConfig 내 .cors(cors -> ...) 및 관련 @Bean 삭제

---

## ✅ 작업 내용
1. WebConfig 클래스에서 addCorsMappings()만 CORS 설정의 진입점으로 유지

---

## 🔗 관련 이슈
- Closes  #15 #16 
---

