### PR TITLE
[TB-15] 토큰 재발급 httponly 쿠키로 변경(1)

### DIFF
--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
@@ -10,7 +10,10 @@ import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
+import java.time.Duration;
 
 @RestController
 @RequestMapping("api/v1/auth")
@@ -25,6 +28,18 @@ public class TokenController implements TokenApiPresentation {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        return tokenUseCase.createNewToken(tokenRequest.getRefreshToken());
+        AccessTokenResponse accessTokenResponse = tokenUseCase.createNewToken(tokenRequest.getRefreshToken());
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenRequest.getRefreshToken())
+                .httpOnly(true)
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("None")
+                .secure(false)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return accessTokenResponse;
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
* 토큰 재발급 httponly 쿠기로 변경

---

## ✅ 작업 내용
1./ token 요청 시에도 refreshToken이 HttpOnly 쿠키로 클라이언트에 전달되도록 수정


---

## 🔗 관련 이슈
- Closes #8 
---

