### PR TITLE
[TB-16] 이메일 인증 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'software.amazon.awssdk:s3:2.25.14'                       // aws s3 (버전 체크 필요)
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.google.guava:guava:32.1.2-jre'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.withType(Test).configureEach {

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/signin/SignInController.java
@@ -28,7 +28,7 @@ public class SignInController implements SignInApiPresentation{
                 .httpOnly(true)
                 .path("/")
                 .maxAge(Duration.ofDays(7))
-                .sameSite("None")
+                .sameSite("Lax")
                 .secure(false)
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/token/TokenController.java
@@ -31,7 +31,7 @@ public class TokenController implements TokenApiPresentation{
                 .httpOnly(true)
                 .path("/")
                 .maxAge(Duration.ofDays(7))
-                .sameSite("None")
+                .sameSite("Lax")
                 .secure(false)
                 .build();
 

--- a/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
                     API_V1_PREFIX + "/users/password",
                     API_V1_PREFIX + "/health",
                     API_V1_PREFIX + "/users/sign-up/check-duplicate-auth-id",
+                    API_V1_PREFIX + "/email/send",
+                    API_V1_PREFIX + "/email/verify",
                     "/api-docs",
                     "/swagger-custom-ui.html",
                     "/v3/api-docs",

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/email/EmailApiPresentation.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/email/EmailApiPresentation.java
@@ -1,0 +1,20 @@
+package com.ClubAccount_BE.user.adapter.in.email;
+
+import com.ClubAccount_BE.user.adapter.in.email.dto.request.EmailSendRequest;
+import com.ClubAccount_BE.user.adapter.in.email.dto.request.EmailVerifyRequest;
+import com.ClubAccount_BE.user.adapter.in.email.dto.response.EmailVerifyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+    @Tag(name = "Email", description = "이메일 인증 관련 API")
+    public interface EmailApiPresentation {
+
+        @Operation(summary = "이메일 인증 코드 전송")
+        ResponseEntity<Void> sendVerificationEmail(@Valid @RequestBody EmailSendRequest request);
+
+        @Operation(summary = "이메일 인증 코드 검증")
+        ResponseEntity<EmailVerifyResponse> verifyCode(@Valid @RequestBody EmailVerifyRequest request);
+    }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/email/EmailController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/email/EmailController.java
@@ -1,0 +1,32 @@
+package com.ClubAccount_BE.user.adapter.in.email;
+
+import com.ClubAccount_BE.user.adapter.in.email.dto.request.EmailSendRequest;
+import com.ClubAccount_BE.user.adapter.in.email.dto.request.EmailVerifyRequest;
+import com.ClubAccount_BE.user.adapter.in.email.dto.response.EmailVerifyResponse;
+import com.ClubAccount_BE.user.application.service.email.EmailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/email")
+@RequiredArgsConstructor
+public class EmailController implements EmailApiPresentation {
+
+    private final EmailService emailService;
+
+    @PostMapping("/send")
+    @Override
+    public ResponseEntity<Void> sendVerificationEmail(@RequestBody @Valid EmailSendRequest request) {
+        emailService.sendVerificationEmail(request.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(value = "/verify", produces = "application/json")
+    @Override
+    public ResponseEntity<EmailVerifyResponse> verifyCode(@RequestBody @Valid EmailVerifyRequest request) {
+            boolean verified = emailService.verifyCode(request.getEmail(), request.getCode());
+            return ResponseEntity.ok(new EmailVerifyResponse(verified, verified ? "✅ 인증 성공" : "❌ 인증 실패"));
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/request/EmailSendRequest.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/request/EmailSendRequest.java
@@ -1,0 +1,16 @@
+package com.ClubAccount_BE.user.adapter.in.email.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailSendRequest {
+    @NotBlank
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @Schema(name = "email", example = "thinkboo@example.com")
+    private String email;
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/request/EmailVerifyRequest.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,22 @@
+package com.ClubAccount_BE.user.adapter.in.email.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class EmailVerifyRequest {
+    @NotBlank
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    @Schema(name = "email", example = "thinkboo@example.com")
+    private String email;
+
+    @NotBlank
+    @Schema(name = "code", example = "0A0012")
+    private String code;
+}
+

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/response/EmailVerifyResponse.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/email/dto/response/EmailVerifyResponse.java
@@ -1,0 +1,16 @@
+package com.ClubAccount_BE.user.adapter.in.email.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerifyResponse {
+    private boolean success;
+    private String message;
+
+    public EmailVerifyResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/InMemoryVerificationAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/InMemoryVerificationAdapter.java
@@ -1,0 +1,23 @@
+package com.ClubAccount_BE.user.adapter.out.persistence;
+
+import com.ClubAccount_BE.user.adapter.out.persistence.repository.VerificationRepository;
+import com.ClubAccount_BE.user.application.port.out.email.VerificationCodePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class InMemoryVerificationAdapter implements VerificationCodePort {
+
+    private final VerificationRepository verificationRepository;
+
+    @Override
+    public void saveCode(String email, String code) {
+        verificationRepository.saveCode(email, code);
+    }
+
+    @Override
+    public String getCode(String email) {
+        return verificationRepository.getCode(email);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/InMemoryVerificationRepository.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/InMemoryVerificationRepository.java
@@ -1,0 +1,21 @@
+package com.ClubAccount_BE.user.adapter.out.persistence.repository;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class InMemoryVerificationRepository implements VerificationRepository {
+    private final Map<String, String> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveCode(String email, String code) {
+        store.put(email, code);
+    }
+
+    @Override
+    public String getCode(String email) {
+        return store.get(email);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/VerificationRepository.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/VerificationRepository.java
@@ -1,0 +1,6 @@
+package com.ClubAccount_BE.user.adapter.out.persistence.repository;
+
+public interface VerificationRepository {
+    void saveCode(String email, String code);
+    String getCode(String email);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/email/EmailUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/email/EmailUseCase.java
@@ -1,0 +1,6 @@
+package com.ClubAccount_BE.user.application.port.in.email;
+
+public interface EmailUseCase {
+    void sendVerificationEmail(String email);
+    boolean verifyCode(String email, String inputCode);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/email/VerificationCodePort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/email/VerificationCodePort.java
@@ -1,0 +1,6 @@
+package com.ClubAccount_BE.user.application.port.out.email;
+
+public interface VerificationCodePort {
+    void saveCode(String email, String code);
+    String getCode(String email);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/service/email/EmailService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/email/EmailService.java
@@ -1,6 +1,5 @@
 package com.ClubAccount_BE.user.application.service.email;
 
-import com.ClubAccount_BE.user.adapter.out.persistence.repository.VerificationRepository;
 import com.ClubAccount_BE.user.application.port.in.email.EmailUseCase;
 import com.ClubAccount_BE.user.application.port.out.email.VerificationCodePort;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ClubAccount_BE/user/application/service/email/EmailService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/email/EmailService.java
@@ -1,0 +1,41 @@
+package com.ClubAccount_BE.user.application.service.email;
+
+import com.ClubAccount_BE.user.adapter.out.persistence.repository.VerificationRepository;
+import com.ClubAccount_BE.user.application.port.in.email.EmailUseCase;
+import com.ClubAccount_BE.user.application.port.out.email.VerificationCodePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class EmailService implements EmailUseCase {
+
+    private final JavaMailSender mailSender;
+    private final VerificationCodePort verificationCodePort;
+
+    @Override
+    public void sendVerificationEmail(String toEmail) {
+        String code = createRandomCode();
+        verificationCodePort.saveCode(toEmail, code);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("띵부 인증코드");
+        message.setText("인증코드: " + code);
+        mailSender.send(message);
+    }
+
+    @Override
+    public boolean verifyCode(String email, String inputCode) {
+        String savedCode = verificationCodePort.getCode(email);
+        return inputCode.equals(savedCode);
+    }
+
+    private String createRandomCode() {
+        return UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
* 이메일 인증 기능 도입
* 이메일 전송 및 인증 확인 로직 구현

---

## ✅ 작업 내용
1. EmailApiPresentation 인터페이스 및 EmailController 작성
2. EmailService 구현 및 인증 코드 생성, 검증 로직 추가
3. EmailSendRequest, EmailVerifyRequest, EmailVerifyResponse 등 DTO 생성
4. VerificationCodePort 포트 생성 및 InMemoryVerificationAdapter 구현체 연결
5. SecurityConfig에서 `/api/v1/email/send`, `/verify` 경로 permitAll로 허용

---

## 📂 리뷰 요구사항
- 이메일 인증 흐름 구조가 명확한지
- 계층분리 괜찮은지

---

