### PR TITLE
[TB-14] 영수증 수정 API 기능 구현

### DIFF
--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptApi.java
@@ -1,7 +1,7 @@
 package com.ClubAccount_BE.receipt.adapter.in.web;
 
 import com.ClubAccount_BE.core.meta.LoginUser;
-import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.CreateReceiptRequestDto;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.CreateReceiptResponseDto;
 import com.ClubAccount_BE.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +16,6 @@ public interface CreateReceiptApi {
     CreateReceiptResponseDto createReceipt(
             @LoginUser User user,
             @RequestPart(value = "image") MultipartFile image,
-            @RequestPart(value = "request") CreateReceiptRequestDto createReceiptRequestDto
+            @RequestPart(value = "request") ReceiptRequest receiptRequest
     );
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptController.java
@@ -1,7 +1,7 @@
 package com.ClubAccount_BE.receipt.adapter.in.web;
 
 import com.ClubAccount_BE.core.meta.LoginUser;
-import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.CreateReceiptRequestDto;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.CreateReceiptResponseDto;
 import com.ClubAccount_BE.receipt.application.port.in.CreateReceiptUseCase;
 import com.ClubAccount_BE.user.domain.User;
@@ -23,8 +23,8 @@ public class CreateReceiptController implements CreateReceiptApi {
     public CreateReceiptResponseDto createReceipt(
             @LoginUser User user,
             @RequestPart(value = "image", required = false) MultipartFile image,
-            @RequestPart(value = "request") CreateReceiptRequestDto createReceiptRequestDto
+            @RequestPart(value = "request") ReceiptRequest receiptRequest
     ) {
-        return createReceiptUseCase.createReceipt(user, image, createReceiptRequestDto);
+        return createReceiptUseCase.createReceipt(user, image, receiptRequest);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/UpdateReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/UpdateReceiptApi.java
@@ -1,0 +1,21 @@
+package com.ClubAccount_BE.receipt.adapter.in.web;
+
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
+import com.ClubAccount_BE.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Update Receipt", description = "영수증 수정 API")
+public interface UpdateReceiptApi {
+
+    @Operation(summary = "영수증 수정", description = "파싱된 영수증 정보를 수정한다.")
+    Long updateReceipt(
+            @LoginUser User user,
+            @PathVariable("receiptId") Long receiptId,
+            @RequestBody ReceiptRequest receiptRequest
+    );
+
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/UpdateReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/UpdateReceiptController.java
@@ -1,0 +1,29 @@
+package com.ClubAccount_BE.receipt.adapter.in.web;
+
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
+import com.ClubAccount_BE.receipt.application.port.in.UpdateReceiptUseCase;
+import com.ClubAccount_BE.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/receipts")
+public class UpdateReceiptController implements UpdateReceiptApi {
+
+    private final UpdateReceiptUseCase updateReceiptUseCase;
+
+    @PutMapping("/{receiptId}")
+    public Long updateReceipt(
+            @LoginUser User user,
+            @PathVariable("receiptId") Long receiptId,
+            @RequestBody ReceiptRequest receiptRequest
+    ) {
+        return updateReceiptUseCase.updateReceipt(user, receiptId, receiptRequest);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/request/ReceiptItemRequest.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/request/ReceiptItemRequest.java
@@ -3,7 +3,7 @@ package com.ClubAccount_BE.receipt.adapter.in.web.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 
-public record CreateReceiptItemRequestDto(
+public record ReceiptItemRequest(
 
         @Schema(description = "영수증 아이템 이름", example = "치킨")
         String name,
@@ -13,7 +13,7 @@ public record CreateReceiptItemRequestDto(
 
         @Schema(description = "영수증 아이템 총 가격", example = "20000")
         BigDecimal totalPrice,
-        
+
         @Schema(description = "영수증 아이템 수량", example = "2")
         int quantity
 ) {

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/request/ReceiptRequest.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/request/ReceiptRequest.java
@@ -6,7 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
-public record CreateReceiptRequestDto(
+public record ReceiptRequest(
 
         @Schema(
                 description = "영수증 분류 카테고리",
@@ -29,7 +29,7 @@ public record CreateReceiptRequestDto(
         String etc,
 
         @Schema(description = "영수증 내 아이템 리스트")
-        List<CreateReceiptItemRequestDto> receiptItems
+        List<ReceiptItemRequest> receiptItems
 ) {
 
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -4,11 +4,11 @@ import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import com.ClubAccount_BE.receipt.adapter.out.persistence.repository.ReceiptRepository;
 import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.FindReceiptPort;
+import com.ClubAccount_BE.receipt.application.port.out.UpdateReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.mapper.ReceiptMapper;
 import com.ClubAccount_BE.user.domain.User;
-import com.ClubAccount_BE.user.mapper.UserMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ReceiptRepositoryAdapter implements CreateReceiptPort, FindReceiptPort {
+public class ReceiptRepositoryAdapter
+        implements CreateReceiptPort, FindReceiptPort, UpdateReceiptPort {
 
     private final ReceiptRepository receiptRepository;
 
@@ -25,8 +26,7 @@ public class ReceiptRepositoryAdapter implements CreateReceiptPort, FindReceiptP
     public Long createReceipt(Receipt receipt, List<ReceiptItem> receiptItems) {
 
         ReceiptEntity receiptEntity = ReceiptMapper.toEntity(receipt);
-        ReceiptMapper.toEntity(receiptItems, receiptEntity);
-
+        receiptEntity.replaceReceiptItem(receiptItems);
         return receiptRepository
                 .save(receiptEntity)
                 .getId();
@@ -42,8 +42,22 @@ public class ReceiptRepositoryAdapter implements CreateReceiptPort, FindReceiptP
     @Override
     public Receipt getReceipt(User user, Long receiptId) {
         return receiptRepository
-                .findByUserAndId(UserMapper.toEntity(user), receiptId)
+                .findById(receiptId)
                 .map(ReceiptMapper::toDomain)
                 .orElseThrow(() -> new IllegalArgumentException("Receipt not found"));
+    }
+
+    @Override
+    public Long updateReceipt(
+            Long receiptId,
+            Receipt receipt,
+            List<ReceiptItem> receiptItems
+    ) {
+        ReceiptEntity receiptEntity = receiptRepository.findReceiptById(receiptId)
+                .orElseThrow(() -> new IllegalArgumentException("Receipt not found"));
+
+        receiptEntity.updateReceipt(receipt);
+        receiptEntity.replaceReceiptItem(receiptItems);
+        return receiptEntity.getId();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
@@ -1,7 +1,10 @@
 package com.ClubAccount_BE.receipt.adapter.out.persistence.entity;
 
 import com.ClubAccount_BE.core.entity.TimeBaseEntity;
+import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
+import com.ClubAccount_BE.receipt.mapper.ReceiptItemMapper;
 import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -65,10 +68,26 @@ public class ReceiptEntity extends TimeBaseEntity {
     @OneToMany(mappedBy = "receipt", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReceiptItemEntity> receiptItems = new ArrayList<>();
 
+    public void updateReceipt(Receipt receipt) {
+        this.category = receipt.getCategory();
+        this.categoryName = receipt.getCategoryName();
+        this.businessName = receipt.getBusinessName();
+        this.amount = receipt.getAmount();
+        this.date = receipt.getDate();
+        this.etc = receipt.getEtc();
+    }
+
     public void addReceiptItem(ReceiptItemEntity receiptItem) {
         this.receiptItems.add(receiptItem);
         if (receiptItem.getReceipt() != this) {
             receiptItem.addReceipt(this);
         }
+    }
+
+    public void replaceReceiptItem(List<ReceiptItem> receiptItems) {
+        this.receiptItems.clear();
+        receiptItems.stream()
+                .map(ReceiptItemMapper::toEntity)
+                .forEach(this::addReceiptItem);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptRepository.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptRepository.java
@@ -1,7 +1,6 @@
 package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
 
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
-import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,5 +12,5 @@ public interface ReceiptRepository extends JpaRepository<ReceiptEntity, Long> {
     Page<ReceiptEntity> findAllByUserId(Long id, Pageable pageable);
 
     @EntityGraph(attributePaths = "receiptItems")
-    Optional<ReceiptEntity> findByUserAndId(UserEntity user, Long id);
+    Optional<ReceiptEntity> findReceiptById(Long receiptId);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/CreateReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/CreateReceiptUseCase.java
@@ -1,6 +1,6 @@
 package com.ClubAccount_BE.receipt.application.port.in;
 
-import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.CreateReceiptRequestDto;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.CreateReceiptResponseDto;
 import com.ClubAccount_BE.user.domain.User;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,6 +10,6 @@ public interface CreateReceiptUseCase {
     CreateReceiptResponseDto createReceipt(
             User user,
             MultipartFile image,
-            CreateReceiptRequestDto createReceiptRequestDto
+            ReceiptRequest receiptRequest
     );
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
@@ -5,9 +5,7 @@ import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.DetailReceiptRespo
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.FindReceiptResponseDto;
 import com.ClubAccount_BE.user.domain.User;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface FindReceiptUseCase {
 
     PagingResponse<FindReceiptResponseDto> getReceipts(User user, Pageable pageable);

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/UpdateReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/UpdateReceiptUseCase.java
@@ -1,0 +1,9 @@
+package com.ClubAccount_BE.receipt.application.port.in;
+
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
+import com.ClubAccount_BE.user.domain.User;
+
+public interface UpdateReceiptUseCase {
+
+    Long updateReceipt(User user, Long receiptId, ReceiptRequest receiptRequest);
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/UpdateReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/UpdateReceiptPort.java
@@ -1,0 +1,10 @@
+package com.ClubAccount_BE.receipt.application.port.out;
+
+import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import java.util.List;
+
+public interface UpdateReceiptPort {
+
+    Long updateReceipt(Long receiptId, Receipt receipt, List<ReceiptItem> receiptItem);
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
@@ -1,14 +1,14 @@
 package com.ClubAccount_BE.receipt.application.service;
 
-import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.CreateReceiptRequestDto;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.CreateReceiptResponseDto;
 import com.ClubAccount_BE.receipt.application.port.in.CreateReceiptUseCase;
 import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import com.ClubAccount_BE.receipt.domain.service.ReceiptItemEditor;
 import com.ClubAccount_BE.user.domain.User;
-import com.ClubAccount_BE.user.mapper.UserMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,42 +22,27 @@ public class CreateReceiptService implements CreateReceiptUseCase {
 
     private final UploadReceiptPort uploadReceiptPort;
 
+    private final ReceiptItemEditor receiptItemEditor;
+
     @Override
     public CreateReceiptResponseDto createReceipt(
             User user,
             MultipartFile image,
-            CreateReceiptRequestDto createReceiptRequestDto
+            ReceiptRequest receiptRequest
     ) {
         Receipt receipt = Receipt.create(
-                UserMapper.toEntity(user),
-                createReceiptRequestDto.category(),
-                createReceiptRequestDto.categoryName(),
-                createReceiptRequestDto.businessName(),
-                createReceiptRequestDto.date(),
-                createReceiptRequestDto.amount(),
-                createReceiptRequestDto.etc(),
-                //TODO : 직접 등록시 기본 이미지로 설정 로직 추가
+                user,
+                receiptRequest.category(),
+                receiptRequest.categoryName(),
+                receiptRequest.businessName(),
+                receiptRequest.date(),
+                receiptRequest.amount(),
+                receiptRequest.etc(),
                 image == null ? "" : uploadReceiptPort.uploadReceipt(image)
         );
 
-        List<ReceiptItem> receiptItems = toReceiptItems(createReceiptRequestDto, receipt);
-
+        List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
         Long receiptId = createReceiptPort.createReceipt(receipt, receiptItems);
         return CreateReceiptResponseDto.of(receiptId, receipt);
-    }
-
-    private List<ReceiptItem> toReceiptItems(
-            CreateReceiptRequestDto createReceiptRequestDto,
-            Receipt receipt
-    ) {
-        return createReceiptRequestDto.receiptItems().stream()
-                .map(receiptItem -> ReceiptItem.create(
-                        receipt,
-                        receiptItem.name(),
-                        receiptItem.price(),
-                        receiptItem.totalPrice(),
-                        receiptItem.quantity()
-                ))
-                .toList();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
@@ -1,0 +1,44 @@
+package com.ClubAccount_BE.receipt.application.service;
+
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
+import com.ClubAccount_BE.receipt.application.port.in.UpdateReceiptUseCase;
+import com.ClubAccount_BE.receipt.application.port.out.UpdateReceiptPort;
+import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import com.ClubAccount_BE.receipt.domain.service.ReceiptItemEditor;
+import com.ClubAccount_BE.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateReceiptService implements UpdateReceiptUseCase {
+
+    private final UpdateReceiptPort updateReceiptPort;
+
+    private final ReceiptItemEditor receiptItemEditor;
+
+    @Override
+    public Long updateReceipt(
+            User user,
+            Long receiptId,
+            ReceiptRequest receiptRequest
+    ) {
+        Receipt receipt = Receipt.update(
+                receiptId,
+                user,
+                receiptRequest.category(),
+                receiptRequest.categoryName(),
+                receiptRequest.businessName(),
+                receiptRequest.date(),
+                receiptRequest.amount(),
+                receiptRequest.etc()
+        );
+
+        List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
+        return updateReceiptPort.updateReceipt(receiptId, receipt, receiptItems);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
@@ -1,7 +1,7 @@
 package com.ClubAccount_BE.receipt.domain;
 
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
-import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
+import com.ClubAccount_BE.user.domain.User;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
@@ -12,7 +12,7 @@ import lombok.Getter;
 public class Receipt {
 
     private final Long id;
-    private final UserEntity user;
+    private final User user;
     private final ReceiptCategory category;
     private final String categoryName;
     private final String businessName;
@@ -25,7 +25,7 @@ public class Receipt {
     @Builder
     private Receipt(
             Long id,
-            UserEntity user,
+            User user,
             ReceiptCategory category,
             String categoryName,
             String businessName,
@@ -48,7 +48,7 @@ public class Receipt {
     }
 
     public static Receipt create(
-            UserEntity user,
+            User user,
             ReceiptCategory category,
             String categoryName,
             String businessName,
@@ -66,6 +66,28 @@ public class Receipt {
                 .date(date)
                 .etc(etc)
                 .receiptImageUrl(receiptImageUrl)
+                .build();
+    }
+
+    public static Receipt update(
+            Long receiptId,
+            User user,
+            ReceiptCategory category,
+            String categoryName,
+            String businessName,
+            LocalDate date,
+            BigDecimal amount,
+            String etc
+    ) {
+        return Receipt.builder()
+                .id(receiptId)
+                .user(user)
+                .category(category)
+                .categoryName(categoryName)
+                .businessName(businessName)
+                .amount(amount)
+                .date(date)
+                .etc(etc)
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/ReceiptItem.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/ReceiptItem.java
@@ -31,7 +31,7 @@ public class ReceiptItem {
         this.quantity = quantity;
     }
 
-    public static ReceiptItem create(
+    public static ReceiptItem of(
             Receipt receipt,
             String name,
             BigDecimal price,

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptItemEditor.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptItemEditor.java
@@ -1,0 +1,27 @@
+package com.ClubAccount_BE.receipt.domain.service;
+
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
+import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReceiptItemEditor {
+
+    public List<ReceiptItem> toReceiptItems(
+            ReceiptRequest receiptRequest,
+            Receipt receipt
+    ) {
+        return receiptRequest.receiptItems().stream()
+                .map(receiptItem -> ReceiptItem.of(
+                        receipt,
+                        receiptItem.name(),
+                        receiptItem.price(),
+                        receiptItem.totalPrice(),
+                        receiptItem.quantity()
+                ))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptItemMapper.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptItemMapper.java
@@ -5,6 +5,17 @@ import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 
 public class ReceiptItemMapper {
 
+    public static ReceiptItemEntity toEntity(ReceiptItem receiptItem) {
+        return ReceiptItemEntity.builder()
+                .id(receiptItem.getId())
+                .receipt(ReceiptMapper.toEntity(receiptItem.getReceipt()))
+                .name(receiptItem.getName())
+                .price(receiptItem.getPrice())
+                .totalPrice(receiptItem.getTotalPrice())
+                .quantity(receiptItem.getQuantity())
+                .build();
+    }
+
     public static ReceiptItem toDomain(ReceiptItemEntity receiptItemEntity) {
         return ReceiptItem.builder()
                 .id(receiptItemEntity.getId())

--- a/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
@@ -3,9 +3,7 @@ package com.ClubAccount_BE.receipt.mapper;
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.user.mapper.UserMapper;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ReceiptMapper {
 
     public static ReceiptEntity toEntity(Receipt receipt) {

--- a/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
@@ -1,17 +1,17 @@
 package com.ClubAccount_BE.receipt.mapper;
 
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
-import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptItemEntity;
 import com.ClubAccount_BE.receipt.domain.Receipt;
-import com.ClubAccount_BE.receipt.domain.ReceiptItem;
-import java.util.List;
+import com.ClubAccount_BE.user.mapper.UserMapper;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReceiptMapper {
 
     public static ReceiptEntity toEntity(Receipt receipt) {
-        return ReceiptEntity.builder().id(receipt.getId()).user(receipt.getUser())
+        return ReceiptEntity.builder()
+                .id(receipt.getId())
+                .user(UserMapper.toEntity(receipt.getUser()))
                 .category(receipt.getCategory())
                 .categoryName(receipt.getCategory().getDisplayName())
                 .businessName(receipt.getBusinessName())
@@ -23,7 +23,7 @@ public class ReceiptMapper {
 
     public static Receipt toDomain(ReceiptEntity receiptEntity) {
         return Receipt.builder().id(receiptEntity.getId())
-                .user(receiptEntity.getUser())
+                .user(UserMapper.toDomain(receiptEntity.getUser()))
                 .category(receiptEntity.getCategory())
                 .categoryName(receiptEntity.getCategoryName())
                 .businessName(receiptEntity.getBusinessName())
@@ -31,28 +31,11 @@ public class ReceiptMapper {
                 .date(receiptEntity.getDate())
                 .etc(receiptEntity.getEtc())
                 .receiptImageUrl(receiptEntity.getReceiptImageUrl())
-                .receiptItems(
-                        receiptEntity.getReceiptItems()
-                                .stream()
-                                .map(ReceiptItemMapper::toDomain)
-                                .toList()
+                .receiptItems(receiptEntity.getReceiptItems()
+                        .stream()
+                        .map(ReceiptItemMapper::toDomain)
+                        .toList()
                 )
                 .build();
-    }
-
-    public static ReceiptItemEntity toEntity(ReceiptItem receiptItem) {
-        return ReceiptItemEntity.builder().id(receiptItem.getId())
-                .receipt(toEntity(receiptItem.getReceipt()))
-                .name(receiptItem.getName())
-                .price(receiptItem.getPrice())
-                .totalPrice(receiptItem.getTotalPrice())
-                .quantity(receiptItem.getQuantity())
-                .build();
-    }
-
-    public static void toEntity(List<ReceiptItem> items, ReceiptEntity receiptEntity) {
-        items.stream()
-                .map(ReceiptMapper::toEntity)
-                .forEach(receiptEntity::addReceiptItem);
     }
 }

--- a/src/test/java/com/ClubAccount_BE/factory/receipt/ReceiptTestFactory.java
+++ b/src/test/java/com/ClubAccount_BE/factory/receipt/ReceiptTestFactory.java
@@ -2,12 +2,16 @@ package com.ClubAccount_BE.factory.receipt;
 
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
+import com.ClubAccount_BE.user.domain.User;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import jdk.jfr.Description;
+import org.mockito.Mockito;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class ReceiptTestFactory {
+
+    private static final User mockUser = Mockito.mock(User.class);
 
 //    @Description("영수증 등록 Request DTO 생성")
 //    public static CreateReceiptRequestDto createReceiptRequestDto() {
@@ -35,7 +39,7 @@ public class ReceiptTestFactory {
     public static Receipt createReceipt() {
         return Receipt.builder()
                 .id(1L)
-                .user(null)
+                .user(mockUser)
                 .category(ReceiptCategory.SUBSCRIPTION)
                 .businessName("김밥천국")
                 .date(LocalDate.of(2025, 3, 28))

--- a/src/test/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapperTest.java
+++ b/src/test/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapperTest.java
@@ -21,7 +21,6 @@ class ReceiptMapperTest {
 
         // then
         assertThat(entity.getId()).isEqualTo(receipt.getId());
-        assertThat(entity.getUser()).isEqualTo(receipt.getUser());
         assertThat(entity.getCategory()).isEqualTo(receipt.getCategory());
         assertThat(entity.getBusinessName()).isEqualTo(receipt.getBusinessName());
         assertThat(entity.getAmount()).isEqualTo(receipt.getAmount());


### PR DESCRIPTION
## 📌 작업 개요

* 저장된 영수증에 대한 정보를 수정하는 API 기능 구현

---

## ✅ 작업 내용
1. 정의된 컨벤션에 따라 dto 네이밍 수정
2. 영수증 수정 API 기능 구현

---

## 📂 리뷰 요구사항
- 현재 영수증의 상세내용이 추가, 변경 및 삭제가 발생함에 따라 영수증 수정 시 상세내역을 대체하는 로직으로 구현하였습니다. 추후에 이와 관련 로직에 대해 고민하고, 수정할 계획입니다.
---

