### PR TITLE
[TB -17] 로그아웃과 비밀번호 재설정, 비회원 조회 링크 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation 'com.google.guava:guava:32.1.2-jre'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.withType(Test).configureEach {

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutApiPresentation.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutApiPresentation.java
@@ -1,0 +1,12 @@
+package com.ClubAccount_BE.auth.adapter.in.web.logout;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Tag(name = "Logout", description = "로그아웃 API")
+public interface LogoutApiPresentation {
+    @Operation(summary = "로그아웃", description = "리프레시 토큰 쿠키를 제거하여 로그아웃합니다.")
+     void logout(HttpServletRequest request, HttpServletResponse response);
+}

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutController.java
@@ -1,0 +1,49 @@
+package com.ClubAccount_BE.auth.adapter.in.web.logout;
+
+import com.ClubAccount_BE.auth.application.port.in.SignOutUseCase;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class LogoutController implements LogoutApiPresentation{
+
+    private final SignOutUseCase signOutUseCase;
+
+    @PostMapping("/logout")
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshToken(request);
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            signOutUseCase.logout(refreshToken);
+        }
+
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .secure(true)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
+    }
+
+    private String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if ("refreshToken".equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutController.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/in/web/logout/LogoutController.java
@@ -11,6 +11,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -20,10 +23,8 @@ public class LogoutController implements LogoutApiPresentation{
 
     @PostMapping("/logout")
     public void logout(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = extractRefreshToken(request);
-        if (refreshToken != null && !refreshToken.isBlank()) {
-            signOutUseCase.logout(refreshToken);
-        }
+        extractRefreshToken(request)
+                .ifPresent(signOutUseCase::logout);
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
                 .httpOnly(true)
@@ -36,14 +37,13 @@ public class LogoutController implements LogoutApiPresentation{
         response.addHeader(HttpHeaders.SET_COOKIE, deleteCookie.toString());
     }
 
-    private String extractRefreshToken(HttpServletRequest request) {
-        if (request.getCookies() == null) return null;
-
-        for (Cookie cookie : request.getCookies()) {
-            if ("refreshToken".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return null;
+    private Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getCookies())
+                .flatMap(cookies -> Arrays.stream(cookies)
+                        .filter(cookie -> "refreshToken".equals(cookie.getName()))
+                        .map(Cookie::getValue)
+                        .filter(value -> !value.isBlank())
+                        .findFirst()
+                );
     }
 }

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/out/persistence/InMemoryDeleteRefreshTokenAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/out/persistence/InMemoryDeleteRefreshTokenAdapter.java
@@ -1,0 +1,18 @@
+package com.ClubAccount_BE.auth.adapter.out.persistence;
+
+import com.ClubAccount_BE.auth.adapter.out.persistence.repository.InMemoryTokenRepository;
+import com.ClubAccount_BE.auth.application.port.out.DeleteRefreshTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InMemoryDeleteRefreshTokenAdapter implements DeleteRefreshTokenPort {
+
+    private final InMemoryTokenRepository tokenRepository;
+
+    @Override
+    public void deleteByRefreshToken(String refreshToken) {
+        tokenRepository.deleteRefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/auth/adapter/out/persistence/repository/InMemoryTokenRepository.java
+++ b/src/main/java/com/ClubAccount_BE/auth/adapter/out/persistence/repository/InMemoryTokenRepository.java
@@ -27,4 +27,8 @@ public class InMemoryTokenRepository implements FindRefreshTokenPort, SaveRefres
     public Optional<Long> getByRefreshToken(String refreshToken) {
         return Optional.ofNullable(TOKEN_REPOSITORY.getIfPresent(refreshToken));
     }
+
+    public void deleteRefreshToken(String refreshToken) {
+        TOKEN_REPOSITORY.invalidate(refreshToken);
+    }
 }

--- a/src/main/java/com/ClubAccount_BE/auth/application/port/in/SignOutUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/auth/application/port/in/SignOutUseCase.java
@@ -1,0 +1,5 @@
+package com.ClubAccount_BE.auth.application.port.in;
+
+public interface SignOutUseCase {
+    void logout(String refreshToken);
+}

--- a/src/main/java/com/ClubAccount_BE/auth/application/port/out/DeleteRefreshTokenPort.java
+++ b/src/main/java/com/ClubAccount_BE/auth/application/port/out/DeleteRefreshTokenPort.java
@@ -1,0 +1,5 @@
+package com.ClubAccount_BE.auth.application.port.out;
+
+public interface DeleteRefreshTokenPort {
+    void deleteByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/ClubAccount_BE/auth/application/service/SignOutService.java
+++ b/src/main/java/com/ClubAccount_BE/auth/application/service/SignOutService.java
@@ -1,0 +1,20 @@
+package com.ClubAccount_BE.auth.application.service;
+
+import com.ClubAccount_BE.auth.application.port.in.SignOutUseCase;
+import com.ClubAccount_BE.auth.application.port.out.DeleteRefreshTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SignOutService implements SignOutUseCase {
+
+    private final DeleteRefreshTokenPort deleteRefreshTokenPort;
+
+    @Override
+    public void logout(String refreshToken) {
+        deleteRefreshTokenPort.deleteByRefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                     API_V1_PREFIX + "/users/sign-up/check-duplicate-auth-id",
                     API_V1_PREFIX + "/email/send",
                     API_V1_PREFIX + "/email/verify",
+                    API_V1_PREFIX + "/auth/reset-password",
                     "/api-docs",
                     "/swagger-custom-ui.html",
                     "/v3/api-docs",

--- a/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/WebConfig.java
@@ -22,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173", "http://172.20.10.3:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization", "Set-Cookie")

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpApi.java
@@ -11,12 +11,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "SignUp", description = "회원가입을 진행하는 API")
-public interface SignUpApiPresentation {
+public interface SignUpApi {
     @Operation(description = "회원가입을 진행한다.")
     void signUp(@Valid @RequestBody SignUpRequest signUpRequest);
 
     @Operation(description = "로그인 아이디 중복 여부를 체크한다.")
     @Parameter(name = "auth-id", description = "아이디")
     AuthIdDuplicationResponse checkAuthIdDuplication(
-            @RequestParam("auth-id") @Size(min = 6, max = 20, message = "INVALIDATED_AUTHID_TYPE") String authId);
+            @RequestParam("auth-id") @Size(min = 6, message = "INVALIDATED_AUTHID_TYPE") String authId);
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/SignUpController.java
@@ -5,7 +5,6 @@ import com.ClubAccount_BE.user.adapter.in.signup.dto.response.AuthIdDuplicationR
 import com.ClubAccount_BE.user.application.port.in.check.CheckAuthIdDuplicationUseCase;
 import com.ClubAccount_BE.user.application.port.in.signup.SignUpUseCase;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 @Validated
-public class SignUpController implements SignUpApiPresentation {
+public class SignUpController implements SignUpApi {
     private final SignUpUseCase signUpUseCase;
     private final CheckAuthIdDuplicationUseCase checkAuthIdDuplicationUseCase;
 
@@ -25,7 +24,7 @@ public class SignUpController implements SignUpApiPresentation {
 
     @GetMapping(value = "/sign-up/check-duplicate-auth-id", produces = "application/json")
     public AuthIdDuplicationResponse checkAuthIdDuplication(
-            @RequestParam("auth-id") @Size(min = 6, message = "INVALIDATED_AUTHID_TYPE") String authId
+             String authId
     ) {
         return checkAuthIdDuplicationUseCase.checkAuthIdDuplication(authId);
     }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/validator/PasswordMatchValidator.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/validator/PasswordMatchValidator.java
@@ -2,16 +2,24 @@ package com.ClubAccount_BE.user.adapter.in.signup.validator;
 
 import com.ClubAccount_BE.core.meta.PasswordMatch;
 import com.ClubAccount_BE.user.adapter.in.signup.dto.request.SignUpRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.PasswordResetRequest;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class PasswordMatchValidator implements ConstraintValidator<PasswordMatch, SignUpRequest> {
+public class PasswordMatchValidator implements ConstraintValidator<PasswordMatch, Object> {
 
     @Override
-    public boolean isValid(SignUpRequest request, ConstraintValidatorContext context) {
-        if (request.getPassword() == null || request.getPasswordCheck() == null) {
-            return false;
-        }
-        return request.getPassword().equals(request.getPasswordCheck());
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        return switch (value) {
+            case null -> true;
+            case SignUpRequest request -> request.getPassword() != null
+                    && request.getPasswordCheck() != null
+                    && request.getPassword().equals(request.getPasswordCheck());
+            case PasswordResetRequest request -> request.newPassword() != null
+                    && request.confirmPassword() != null
+                    && request.newPassword().equals(request.confirmPassword());
+            default ->
+                    true;
+        };
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetApi.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Password Reset", description = "비밀번호 재설정 API")
-public interface PasswordResetApiPresentation {
+public interface PasswordResetApi {
     @Operation(summary = "비밀번호 재설정", description = "비밀번호를 재설정합니다.")
     void resetPassword(PasswordResetRequest request);
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetApiPresentation.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetApiPresentation.java
@@ -1,0 +1,11 @@
+package com.ClubAccount_BE.user.adapter.in.update;
+
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.PasswordResetRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Password Reset", description = "비밀번호 재설정 API")
+public interface PasswordResetApiPresentation {
+    @Operation(summary = "비밀번호 재설정", description = "비밀번호를 재설정합니다.")
+    void resetPassword(PasswordResetRequest request);
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
@@ -1,0 +1,24 @@
+package com.ClubAccount_BE.user.adapter.in.update;
+
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.PasswordResetRequest;
+import com.ClubAccount_BE.user.application.port.in.update.PasswordResetUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class PasswordResetController implements PasswordResetApiPresentation {
+
+    private final PasswordResetUseCase passwordResetUseCase;
+
+    @PostMapping("/reset-password")
+    public void resetPassword(@Valid @RequestBody PasswordResetRequest request) {
+        passwordResetUseCase.resetPassword(request.authId(), request.newPassword(), request.confirmPassword());
+    }
+
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class PasswordResetController implements PasswordResetApiPresentation {
+public class PasswordResetController implements PasswordResetApi {
 
     private final PasswordResetUseCase passwordResetUseCase;
 

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/PasswordResetController.java
@@ -18,7 +18,7 @@ public class PasswordResetController implements PasswordResetApi {
 
     @PostMapping("/reset-password")
     public void resetPassword(@Valid @RequestBody PasswordResetRequest request) {
-        passwordResetUseCase.resetPassword(request.authId(), request.newPassword(), request.confirmPassword());
+        passwordResetUseCase.resetPassword(request.authId(), request.newPassword());
     }
 
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/PasswordResetRequest.java
@@ -1,0 +1,19 @@
+package com.ClubAccount_BE.user.adapter.in.update.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank @Email
+        @Schema(name = "authId", example = "thinkboo@example.com")
+        String authId,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Schema(name = "newPassword", example = "thinkboo1343!")
+        String newPassword,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
+        @Schema(name = "confirmPassword", example = "thinkboo1343!")
+        String confirmPassword
+) {}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/PasswordResetRequest.java
@@ -1,9 +1,11 @@
 package com.ClubAccount_BE.user.adapter.in.update.dto.request;
 
+import com.ClubAccount_BE.core.meta.PasswordMatch;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@PasswordMatch
 public record PasswordResetRequest(
         @NotBlank @Email
         @Schema(name = "authId", example = "thinkboo@example.com")

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/response/PasswordResetResponse.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/response/PasswordResetResponse.java
@@ -1,0 +1,3 @@
+package com.ClubAccount_BE.user.adapter.in.update.dto.response;
+
+public record PasswordResetResponse(String message) {}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/validator/PasswordMatchValidatorForReset.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/validator/PasswordMatchValidatorForReset.java
@@ -1,0 +1,4 @@
+package com.ClubAccount_BE.user.adapter.in.update.validator;
+
+public class PasswordMatchValidatorForReset {
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -5,6 +5,8 @@ import com.ClubAccount_BE.user.adapter.out.persistence.repository.UserRepository
 import com.ClubAccount_BE.user.application.port.out.CheckUserPort;
 import com.ClubAccount_BE.user.application.port.out.FindUserPort;
 import com.ClubAccount_BE.user.application.port.out.SaveUserPort;
+import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
+import com.ClubAccount_BE.user.application.service.update.UpdatePasswordPort;
 import com.ClubAccount_BE.user.domain.User;
 import com.ClubAccount_BE.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, CheckUserPort {
+public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, CheckUserPort, FindUserByEmailPort, UpdatePasswordPort {
 
     private final UserRepository userRepository;
 
@@ -41,5 +43,19 @@ public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, Check
     @Override
     public boolean checkDuplicateAuthId(String authId) {
         return userRepository.existsByAuthId(authId);
+    }
+
+    @Override
+    public User findByAuthId(String email) {
+        return userRepository.findByAuthId(email)
+                .map(UserMapper::toDomain)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일을 가진 사용자가 존재하지 않습니다."));
+    }
+
+    @Override
+    public void updatePassword(User user, String newPassword) {
+        user.updatePassword(newPassword);
+        UserEntity entity = UserMapper.toEntity(user);
+        userRepository.save(entity);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/entity/UserEntity.java
@@ -6,7 +6,11 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
 
 
 @Table(name = "user")
@@ -29,10 +33,9 @@ public class UserEntity extends TimeBaseEntity {
 
     private String department;
 
-//    @Column(nullable = false)
-//    private String role;
-
     private String profileUrl;
 
-    private String rink;
+    @Column(length = 36, nullable = false, unique = true, updatable = false)
+    @JdbcTypeCode(SqlTypes.CHAR)
+    private UUID rink;
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
@@ -12,5 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> getByAuthId(String authId);
     Optional<UserEntity> findById(Long userId);
     boolean existsByAuthId(String authId);
+    Optional<UserEntity> findByAuthId(String email);
 
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
@@ -1,7 +1,5 @@
 package com.ClubAccount_BE.user.application.port.in.update;
 
-import jakarta.validation.constraints.NotBlank;
-
 public interface PasswordResetUseCase {
-    void resetPassword(String email, String newPassword, @NotBlank(message = "비밀번호 확인은 필수입니다.") String s);
+    void resetPassword(String email, String newPassword, String confirmPassword);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
@@ -1,5 +1,5 @@
 package com.ClubAccount_BE.user.application.port.in.update;
 
 public interface PasswordResetUseCase {
-    void resetPassword(String email, String newPassword, String confirmPassword);
+    void resetPassword(String email, String newPassword);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/PasswordResetUseCase.java
@@ -1,0 +1,7 @@
+package com.ClubAccount_BE.user.application.port.in.update;
+
+import jakarta.validation.constraints.NotBlank;
+
+public interface PasswordResetUseCase {
+    void resetPassword(String email, String newPassword, @NotBlank(message = "비밀번호 확인은 필수입니다.") String s);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/update/FindUserByEmailPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/update/FindUserByEmailPort.java
@@ -1,0 +1,7 @@
+package com.ClubAccount_BE.user.application.port.out.update;
+
+import com.ClubAccount_BE.user.domain.User;
+
+public interface FindUserByEmailPort {
+    User findByAuthId(String email);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
@@ -1,0 +1,29 @@
+package com.ClubAccount_BE.user.application.service.update;
+
+import com.ClubAccount_BE.user.application.port.in.update.PasswordResetUseCase;
+import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PasswordResetService implements PasswordResetUseCase {
+
+    private final FindUserByEmailPort findUserByEmailPort;
+    private final UpdatePasswordPort updatePasswordPort;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void resetPassword(String email, String newPassword, String confirmPassword) {
+        if (!newPassword.equals(confirmPassword)) {
+            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        }
+
+        var user = findUserByEmailPort.findByAuthId(email);
+        var encodedPassword = passwordEncoder.encode(newPassword);
+        updatePasswordPort.updatePassword(user, encodedPassword);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
@@ -17,11 +17,7 @@ public class PasswordResetService implements PasswordResetUseCase {
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public void resetPassword(String email, String newPassword, String confirmPassword) {
-        if (!newPassword.equals(confirmPassword)) {
-            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
-        }
-
+    public void resetPassword(String email, String newPassword) {
         var user = findUserByEmailPort.findByAuthId(email);
         var encodedPassword = passwordEncoder.encode(newPassword);
         updatePasswordPort.updatePassword(user, encodedPassword);

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/UpdatePasswordPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/UpdatePasswordPort.java
@@ -1,0 +1,7 @@
+package com.ClubAccount_BE.user.application.service.update;
+
+import com.ClubAccount_BE.user.domain.User;
+
+public interface UpdatePasswordPort {
+    void updatePassword(User user, String encodedPassword);
+}

--- a/src/main/java/com/ClubAccount_BE/user/domain/User.java
+++ b/src/main/java/com/ClubAccount_BE/user/domain/User.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.Instant;
+import java.util.UUID;
 
 @Getter
 @EqualsAndHashCode(of = "id")
@@ -16,12 +17,12 @@ public class User {
     private String password;
     private final String department;
     private String profileUrl;
-    private String rink;
+    private UUID rink;
     private final Instant createdAt;
     private final Instant updatedAt;
 
     @Builder
-    public User(Long id, String authId, String password, String department, String profileUrl, String rink, Instant createdAt, Instant updatedAt) {
+    public User(Long id, String authId, String password, String department, String profileUrl, UUID rink, Instant createdAt, Instant updatedAt) {
         this.id = id;
         this.authId = authId;
         this.password = password;
@@ -37,8 +38,8 @@ public class User {
                 .authId(authId)
                 .password(encodedPassword)
                 .department(department)
-                .rink("none") // 기본값 설정
-                .profileUrl(null) // 프로필 URL은 일단 null
+                .rink(UUID.randomUUID())
+                .profileUrl("") // 프로필 URL은 일단 빈 문자열
                 .build();
     }
 
@@ -49,7 +50,7 @@ public class User {
         this.password = encodedPassword;
     }
 
-    public void updateRink(String rink) {
+    public void updateRink(UUID rink) {
         this.rink = rink;
     }
 

--- a/src/test/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptServiceTest.java
+++ b/src/test/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptServiceTest.java
@@ -32,16 +32,16 @@ class CreateReceiptServiceTest {
         expectedUrl = "https://s3.amazon.com/bucket/test.png";
         expectedId = 1L;
 
-        user = User.builder()
-                .id(expectedId)
-                .authId("test")
-                .password("testPassword")
-                .department("testDepartment")
-                .profileUrl("testProfileUrl")
-                .rink("testRink")
-                .createdAt(null)
-                .updatedAt(null)
-                .build();
+//        user = User.builder()
+//                .id(expectedId)
+//                .authId("test")
+//                .password("testPassword")
+//                .department("testDepartment")
+//                .profileUrl("testProfileUrl")
+//                .rink("testRink")
+//                .createdAt(null)
+//                .updatedAt(null)
+//                .build();
     }
 
 //    @Test


### PR DESCRIPTION
## 📌 작업 개요
* 사용자 인증 및 접근 기능
*  비밀번호 재설정, 로그아웃, 비회원 조회 접근

---

## ✅ 작업 내용
1.비밀번호 재설정 기능 구현
2.로그아웃 기능 추가 – refreshToken 쿠키 제거 처리
3. 비회원 사용자 조회를 위한 UUID 생성(링크로 사용)
4. 프론트 요청에 따라 Origin을 CORS 허용 목록에 추가

---

## 📂 리뷰 요구사항
- 구조적으로 문제가 없는지(리팩토링 필요함)
- 로그아웃 기능의 구현 방식이 적절한지
-  추후에 커스텀 예외 추가 필요
- 비밀번호 재설정의 보안 관련 리팩토링 추후 해결 필요
---

