### PR TITLE
[TB-19] 링크를 통해 접속한 비회원에 대해 영수증 조회 허용

### DIFF
--- a/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/SecurityConfig.java
@@ -1,6 +1,10 @@
 package com.ClubAccount_BE.core.config;
 
-import com.ClubAccount_BE.auth.security.*;
+import com.ClubAccount_BE.auth.security.JwtAccessDeniedHandler;
+import com.ClubAccount_BE.auth.security.JwtAuthenticationEntryPoint;
+import com.ClubAccount_BE.auth.security.JwtAuthenticationProvider;
+import com.ClubAccount_BE.auth.security.TokenAuthenticationFilter;
+import com.ClubAccount_BE.auth.security.TokenProvider;
 import com.ClubAccount_BE.user.application.port.in.FindUserUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
     public static final String API_V1_PREFIX = "/api/v1";
 
     private final TokenProvider tokenProvider;
@@ -30,43 +35,46 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers(
-                    API_V1_PREFIX + "/users/sign-up/**",
-                    API_V1_PREFIX + "/auth/sign-in",
-                    API_V1_PREFIX + "/auth/token",
-                    API_V1_PREFIX + "/users/{student-number}/validate",
-                    API_V1_PREFIX + "/users/password",
-                    API_V1_PREFIX + "/health",
-                    API_V1_PREFIX + "/users/sign-up/check-duplicate-auth-id",
-                    API_V1_PREFIX + "/email/send",
-                    API_V1_PREFIX + "/email/verify",
-                    API_V1_PREFIX + "/auth/reset-password",
-                    "/api-docs",
-                    "/swagger-custom-ui.html",
-                    "/v3/api-docs",
-                    "/v3/api-docs/**",
-                    "/swagger-ui/**",
-                    "/api-docs/**",
-                    "/swagger-ui.html"
-                ).permitAll()
-                .anyRequest().authenticated()
-            )
-            .csrf(AbstractHttpConfigurer::disable)
-            .headers(AbstractHttpConfigurer::disable)
-            .formLogin(AbstractHttpConfigurer::disable)
-            .httpBasic(AbstractHttpConfigurer::disable)
-            .rememberMe(AbstractHttpConfigurer::disable)
-            .logout(AbstractHttpConfigurer::disable)
-            .exceptionHandling(ex -> ex
-                .accessDeniedHandler(jwtAccessDeniedHandler)
-                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-            )
-            .sessionManagement(sess -> sess
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            )
-            .cors(Customizer.withDefaults())
-            .addFilterBefore(tokenAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                API_V1_PREFIX + "/users/sign-up/**",
+                                API_V1_PREFIX + "/auth/sign-in",
+                                API_V1_PREFIX + "/auth/token",
+                                API_V1_PREFIX + "/users/{student-number}/validate",
+                                API_V1_PREFIX + "/users/password",
+                                API_V1_PREFIX + "/health",
+                                API_V1_PREFIX + "/users/sign-up/check-duplicate-auth-id",
+                                API_V1_PREFIX + "/email/send",
+                                API_V1_PREFIX + "/email/verify",
+                                API_V1_PREFIX + "/auth/reset-password",
+                                API_V1_PREFIX + "{link}/receipts",
+                                API_V1_PREFIX + "{link}/receipts/{receiptId}",
+                                "/api-docs",
+                                "/swagger-custom-ui.html",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/api-docs/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
+                .sessionManagement(sess -> sess
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .cors(Customizer.withDefaults())
+                .addFilterBefore(tokenAuthenticationFilter(tokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -78,7 +86,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(JwtAuthenticationProvider jwtAuthenticationProvider) {
+    public AuthenticationManager authenticationManager(
+            JwtAuthenticationProvider jwtAuthenticationProvider) {
         return new ProviderManager(jwtAuthenticationProvider);
     }
 

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
@@ -1,12 +1,11 @@
 package com.ClubAccount_BE.receipt.adapter.in.web;
 
-import com.ClubAccount_BE.core.meta.LoginUser;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.api.FindReceiptApi;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import com.ClubAccount_BE.receipt.application.port.in.FindReceiptUseCase;
-import com.ClubAccount_BE.user.domain.User;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -18,24 +17,24 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/receipts")
+@RequestMapping("/api/v1")
 public class FindReceiptController implements FindReceiptApi {
 
     private final FindReceiptUseCase findReceiptUseCase;
 
-    @GetMapping
-    public PagingResponse<ReceiptResponse> getReceipts(
-            @LoginUser User user,
+    @GetMapping("{link}/receipts")
+    public PagingResponse<ReceiptResponse> getReceiptList(
+            @PathVariable(value = "link") UUID link,
             @PageableDefault(page = 1, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     ) {
-        return findReceiptUseCase.getReceipts(user, pageable);
+        return findReceiptUseCase.getReceiptList(link, pageable);
     }
 
-    @GetMapping("/{receiptId}")
+    @GetMapping("{link}/receipts/{receiptId}")
     public ReceiptDetailResponse getReceipt(
-            @LoginUser User user,
+            @PathVariable(value = "link") UUID link,
             @PathVariable("receiptId") Long receiptId
     ) {
-        return findReceiptUseCase.getReceipt(user, receiptId);
+        return findReceiptUseCase.getReceipt(link, receiptId);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
@@ -1,12 +1,11 @@
 package com.ClubAccount_BE.receipt.adapter.in.web.api;
 
-import com.ClubAccount_BE.core.meta.LoginUser;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
-import com.ClubAccount_BE.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -16,14 +15,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface FindReceiptApi {
 
     @Operation(summary = "영수증 목록 조회", description = "파싱된 영수증 정보를 조회한다.")
-    PagingResponse<ReceiptResponse> getReceipts(
-            @LoginUser User user,
+    PagingResponse<ReceiptResponse> getReceiptList(
+            @PathVariable(value = "link") UUID link,
             @PageableDefault(page = 1, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     );
 
     @Operation(summary = "영수증 상세 목록 조회", description = "파싱된 영수증 정보를 조회한다.")
     ReceiptDetailResponse getReceipt(
-            @LoginUser User user,
+            @PathVariable(value = "link") UUID link,
             @PathVariable("receiptId") Long receiptId
     );
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -32,7 +32,7 @@ public class ReceiptRepositoryAdapter
     }
 
     @Override
-    public Page<Receipt> getReceipts(User user, Pageable pageable) {
+    public Page<Receipt> getReceiptList(User user, Pageable pageable) {
         return receiptRepository
                 .findAllByUserId(user.getId(), pageable)
                 .map(ReceiptMapper::toDomain);

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
@@ -3,12 +3,12 @@ package com.ClubAccount_BE.receipt.application.port.in;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
-import com.ClubAccount_BE.user.domain.User;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface FindReceiptUseCase {
 
-    PagingResponse<ReceiptResponse> getReceipts(User user, Pageable pageable);
+    PagingResponse<ReceiptResponse> getReceiptList(UUID link, Pageable pageable);
 
-    ReceiptDetailResponse getReceipt(User user, Long receiptId);
+    ReceiptDetailResponse getReceipt(UUID link, Long receiptId);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface FindReceiptPort {
 
-    Page<Receipt> getReceipts(User user, Pageable pageable);
+    Page<Receipt> getReceiptList(User user, Pageable pageable);
 
     Receipt getReceipt(User user, Long receiptId);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
@@ -6,7 +6,9 @@ import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import com.ClubAccount_BE.receipt.application.port.in.FindReceiptUseCase;
 import com.ClubAccount_BE.receipt.application.port.out.FindReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.user.application.port.out.FindUserPort;
 import com.ClubAccount_BE.user.domain.User;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,18 +21,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class FindReceiptService implements FindReceiptUseCase {
 
     private final FindReceiptPort findReceiptPort;
+    private final FindUserPort findUserPort;
 
     @Override
-    public PagingResponse<ReceiptResponse> getReceipts(User user, Pageable pageable) {
+    public PagingResponse<ReceiptResponse> getReceiptList(UUID link, Pageable pageable) {
+
+        User user = findUserPort.getUserByLink(link);
         Page<ReceiptResponse> page = findReceiptPort
-                .getReceipts(user, pageable)
+                .getReceiptList(user, pageable)
                 .map(ReceiptResponse::of);
 
         return PagingResponse.of(page);
     }
 
     @Override
-    public ReceiptDetailResponse getReceipt(User user, Long receiptId) {
+    public ReceiptDetailResponse getReceipt(UUID link, Long receiptId) {
+
+        User user = findUserPort.getUserByLink(link);
         Receipt receipt = findReceiptPort.getReceipt(user, receiptId);
         return ReceiptDetailResponse.of(receipt);
     }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -9,12 +9,14 @@ import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
 import com.ClubAccount_BE.user.application.service.update.UpdatePasswordPort;
 import com.ClubAccount_BE.user.domain.User;
 import com.ClubAccount_BE.user.mapper.UserMapper;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, CheckUserPort, FindUserByEmailPort, UpdatePasswordPort {
+public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, CheckUserPort,
+        FindUserByEmailPort, UpdatePasswordPort {
 
     private final UserRepository userRepository;
 
@@ -39,6 +41,12 @@ public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, Check
                 .orElseThrow(() -> new IllegalArgumentException("해당 아이디의 사용자를 찾을 수 없습니다."));
     }
 
+    @Override
+    public User getUserByLink(UUID link) {
+        return userRepository.findByRink(link)
+                .map(UserMapper::toDomain)
+                .orElseThrow(() -> new IllegalArgumentException("해당 링크의 사용자를 찾을 수 없습니다."));
+    }
 
     @Override
     public boolean checkDuplicateAuthId(String authId) {

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/repository/UserRepository.java
@@ -1,17 +1,21 @@
 package com.ClubAccount_BE.user.adapter.out.persistence.repository;
 
 import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> getByAuthId(String authId);
+
     Optional<UserEntity> findById(Long userId);
+
     boolean existsByAuthId(String authId);
+
     Optional<UserEntity> findByAuthId(String email);
 
+    Optional<UserEntity> findByRink(UUID rink);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/FindUserPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/FindUserPort.java
@@ -1,9 +1,13 @@
 package com.ClubAccount_BE.user.application.port.out;
 
 import com.ClubAccount_BE.user.domain.User;
+import java.util.UUID;
 
 public interface FindUserPort {
+
     User getUserByAuthId(String email);
 
     User getUserById(Long userId);
+
+    User getUserByLink(UUID link);
 }


### PR DESCRIPTION
## 📌 작업 개요
* 로그인하지 않은 비회원일 경우, 해당 조직 내에 등록된 영수증을 조회가 가능하도록 로직 수정

---

## ✅ 작업 내용
1. 상세 조회 및 단일 조회에 대한 메서드명 수정
2. PathVariable로 해당 조직의 UUID를 판별하여 영수증을 조회가 가능하도록 로직 수정

---

## 📂 리뷰 요구사항
- 현재 User 엔티티 내 rink가 아닌 link로 수정이 필요할 듯 합니다.
---

