### PR TITLE
[TB-22] 영수증 날짜 필터링 조회 API 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     implementation 'com.google.guava:guava:32.1.2-jre'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.withType(Test).configureEach {

--- a/src/main/java/com/ClubAccount_BE/core/config/QueryDSLConfig.java
+++ b/src/main/java/com/ClubAccount_BE/core/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.ClubAccount_BE.core.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
@@ -5,11 +5,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
-    AUTHENTICATION_FAIL_FORBIDDEN("AUTH_403_FORBIDDEN", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    AUTHENTICATION_FAIL_UNAUTHORIZED("AUTH_401_UNAUTHORIZED", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
-    INCORRECT_PASSWORD("AUTH_401_INCORRECT_PASSWORD", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    DUPLICATED_AUTHID("AUTH_400_DUPLICATED_AUTHID", "이미 존재하는 아이디입니다.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED("A001", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED);
+    AUTHENTICATION_FAIL_FORBIDDEN("1001", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    AUTHENTICATION_FAIL_UNAUTHORIZED("1002", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    INCORRECT_PASSWORD("1003", "비밀번호가 일치하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    DUPLICATED_AUTHID("1004", "이미 존재하는 아이디입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("1005", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+
+    INVALID_START_DATE_AFTER_END_DATE("2001", "시작일은 종료일보다 빠르거나 같아야 합니다.", HttpStatus.BAD_REQUEST);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
@@ -6,14 +6,17 @@ import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryRes
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import com.ClubAccount_BE.receipt.application.port.in.FindReceiptUseCase;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,9 +29,11 @@ public class FindReceiptController implements FindReceiptApi {
     @GetMapping("/{link}/receipts")
     public PagingResponse<ReceiptResponse> getReceiptList(
             @PathVariable(value = "link") UUID link,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @PageableDefault(page = 1, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     ) {
-        return findReceiptUseCase.getReceiptList(link, pageable);
+        return findReceiptUseCase.getReceiptList(link, startDate, endDate, pageable);
     }
 
     @GetMapping("/{link}/receipts/{receiptId}")

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
@@ -18,7 +18,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "Find Receipt", description = "영수증 조회 API")
 public interface FindReceiptApi {
 
-    @Operation(summary = "영수증 목록 조회", description = "파싱된 영수증 정보를 조회한다.")
+    @Operation(
+            summary = "영수증 목록 조회",
+            description = "시작일과 종료일을 기준으로 파싱된 영수증을 조회한다. "
+                    + "시작일과 종료일에 정보가 없을 경우 모든 영수증을 조회한다.")
     PagingResponse<ReceiptResponse> getReceiptList(
             @PathVariable(value = "link") UUID link,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
@@ -6,11 +6,14 @@ import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailRespo
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Find Receipt", description = "영수증 조회 API")
 public interface FindReceiptApi {
@@ -18,6 +21,8 @@ public interface FindReceiptApi {
     @Operation(summary = "영수증 목록 조회", description = "파싱된 영수증 정보를 조회한다.")
     PagingResponse<ReceiptResponse> getReceiptList(
             @PathVariable(value = "link") UUID link,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @PageableDefault(page = 1, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     );
 

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -9,6 +9,7 @@ import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.mapper.ReceiptMapper;
 import com.ClubAccount_BE.user.domain.User;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -32,9 +33,14 @@ public class ReceiptRepositoryAdapter
     }
 
     @Override
-    public Page<Receipt> getReceiptList(User user, Pageable pageable) {
+    public Page<Receipt> getReceiptList(
+            User user,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    ) {
         return receiptRepository
-                .findAllByUserId(user.getId(), pageable)
+                .findAllByDate(user.getId(), startDate, endDate, pageable)
                 .map(ReceiptMapper::toDomain);
     }
 

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepository.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepository.java
@@ -1,0 +1,16 @@
+package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
+
+import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReceiptCustomRepository {
+
+    Page<ReceiptEntity> findAllByDate(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ReceiptCustomRepositoryImpl implements ReceiptCustomRepository {
         List<ReceiptEntity> content = queryFactory
                 .selectFrom(receipt)
                 .where(where)
-                .orderBy(receipt.date.asc())
+                .orderBy(receipt.date.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
+
+import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.QReceiptEntity;
+import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class ReceiptCustomRepositoryImpl implements ReceiptCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ReceiptEntity> findAllByDate(
+            Long userId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    ) {
+        QReceiptEntity receipt = QReceiptEntity.receiptEntity;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(receipt.user.id.eq(userId));
+
+        if (startDate != null && endDate != null) {
+            where.and(receipt.date.between(startDate, endDate));
+        }
+
+        List<ReceiptEntity> content = queryFactory
+                .selectFrom(receipt)
+                .where(where)
+                .orderBy(receipt.date.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> count = queryFactory
+                .select(receipt.count())
+                .from(receipt)
+                .where(where);
+
+        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptRepository.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptRepository.java
@@ -3,14 +3,11 @@ package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReceiptRepository extends JpaRepository<ReceiptEntity, Long> {
-
-    Page<ReceiptEntity> findAllByUserId(Long id, Pageable pageable);
+public interface ReceiptRepository extends JpaRepository<ReceiptEntity, Long>,
+        ReceiptCustomRepository {
 
     List<ReceiptEntity> findAllByUserId(Long id);
 

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
@@ -4,6 +4,7 @@ import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
@@ -11,7 +12,12 @@ public interface FindReceiptUseCase {
 
     ReceiptCategoryResponse getReceiptCategoryRatio(UUID link);
 
-    PagingResponse<ReceiptResponse> getReceiptList(UUID link, Pageable pageable);
+    PagingResponse<ReceiptResponse> getReceiptList(
+            UUID link,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    );
 
     ReceiptDetailResponse getReceipt(UUID link, Long receiptId);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
@@ -2,13 +2,19 @@ package com.ClubAccount_BE.receipt.application.port.out;
 
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.user.domain.User;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface FindReceiptPort {
 
-    Page<Receipt> getReceiptList(User user, Pageable pageable);
+    Page<Receipt> getReceiptList(
+            User user,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    );
 
     List<Receipt> getReceiptCategoryList(User user);
 

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
@@ -13,10 +13,12 @@ import com.ClubAccount_BE.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CreateReceiptService implements CreateReceiptUseCase {
 
     private final CreateReceiptPort createReceiptPort;

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
@@ -11,6 +11,7 @@ import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
 import com.ClubAccount_BE.user.application.port.out.FindUserPort;
 import com.ClubAccount_BE.user.domain.User;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -36,13 +37,18 @@ public class FindReceiptService implements FindReceiptUseCase {
         return ReceiptDetailResponse.of(receipt);
     }
 
-    
+
     @Override
-    public PagingResponse<ReceiptResponse> getReceiptList(UUID link, Pageable pageable) {
+    public PagingResponse<ReceiptResponse> getReceiptList(
+            UUID link,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable
+    ) {
 
         User user = findUserPort.getUserByLink(link);
         Page<ReceiptResponse> page = findReceiptPort
-                .getReceiptList(user, pageable)
+                .getReceiptList(user, startDate, endDate, pageable)
                 .map(ReceiptResponse::of);
 
         return PagingResponse.of(page);

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
@@ -1,5 +1,7 @@
 package com.ClubAccount_BE.receipt.application.service;
 
+import static com.ClubAccount_BE.core.exception.ErrorCode.INVALID_START_DATE_AFTER_END_DATE;
+
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
@@ -45,6 +47,9 @@ public class FindReceiptService implements FindReceiptUseCase {
             LocalDate endDate,
             Pageable pageable
     ) {
+        if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException(INVALID_START_DATE_AFTER_END_DATE.getMessage());
+        }
 
         User user = findUserPort.getUserByLink(link);
         Page<ReceiptResponse> page = findReceiptPort


### PR DESCRIPTION
## 📌 작업 개요
* 기존 영수증 조회하는 API에 날짜 필터링이 가능하게끔 조건을 처리
* queryDSL을 통해 쿼리 조건을 분기하는 로직 작성

---

## ✅ 작업 내용
1. queryDSL 의존성 추가
2. 모든 영수증 조회와 날짜 필터링 조회에 대해 컨트롤러를 분기하고자 하였으나, 불필요한 코드 중복이 생겨 queryDSL을 통해 조건에 따라 쿼리를 호출하도록 구현

---

## 📂 리뷰 요구사항

- `ReceiptCustomRepository` 와 같이 네이밍을 정하였으나, 추후 컨벤션에 따른 변경이 필요할 것 같습니다.
---

