### PR TITLE
[TB-24] 마이페이지 조회 & 수정

### DIFF
--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/validator/PasswordMatchValidator.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/signup/validator/PasswordMatchValidator.java
@@ -3,6 +3,7 @@ package com.ClubAccount_BE.user.adapter.in.signup.validator;
 import com.ClubAccount_BE.core.meta.PasswordMatch;
 import com.ClubAccount_BE.user.adapter.in.signup.dto.request.SignUpRequest;
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.PasswordResetRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.LoginUserUpdatePassword;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
@@ -16,6 +17,9 @@ public class PasswordMatchValidator implements ConstraintValidator<PasswordMatch
                     && request.getPasswordCheck() != null
                     && request.getPassword().equals(request.getPasswordCheck());
             case PasswordResetRequest request -> request.newPassword() != null
+                    && request.confirmPassword() != null
+                    && request.newPassword().equals(request.confirmPassword());
+            case LoginUserUpdatePassword request -> request.newPassword() != null
                     && request.confirmPassword() != null
                     && request.newPassword().equals(request.confirmPassword());
             default ->

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
@@ -1,6 +1,7 @@
 package com.ClubAccount_BE.user.adapter.in.update;
 
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.LoginUserUpdatePassword;
 import com.ClubAccount_BE.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Profile", description = "프로필 관련 API")
 public interface ProfileApi {
@@ -22,5 +24,11 @@ public interface ProfileApi {
     @Operation(summary = "사용자 링크 재생성", description = "회원 UUID 기반 사용자 링크를 새로 발급합니다.")
     void updateLink(
             @Parameter(hidden = true) User user
+    );
+
+    @Operation(summary = "비밀번호 변경", description = "기존 비밀번호를 확인하고 새로운 비밀번호로 변경합니다.")
+    void changePassword(
+            @Parameter(hidden = true) User user,
+            @RequestBody @Valid LoginUserUpdatePassword request
     );
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
@@ -1,0 +1,14 @@
+package com.ClubAccount_BE.user.adapter.in.update;
+
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Profile", description = "프로필 관련 API")
+public interface ProfileApi {
+    @Operation(summary = "프로필 수정", description = "조직명, 이메일, 프로필 이미지를 선택적으로 수정합니다.")
+    void updateProfile(@Valid ProfileUpdateRequest dto, @Parameter(hidden = true)User user);
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
@@ -2,11 +2,13 @@ package com.ClubAccount_BE.user.adapter.in.update;
 
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.LoginUserUpdatePassword;
+import com.ClubAccount_BE.user.adapter.in.update.dto.response.UserProfileResponse;
 import com.ClubAccount_BE.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,5 +32,11 @@ public interface ProfileApi {
     void changePassword(
             @Parameter(hidden = true) User user,
             @RequestBody @Valid LoginUserUpdatePassword request
+    );
+
+    @Operation(summary = "프로필 조회", description = "현재 로그인된 사용자의 프로필 정보를 조회합니다.")
+    @GetMapping
+    UserProfileResponse getProfile(
+            @Parameter(hidden = true) User user
     );
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileApi.java
@@ -6,9 +6,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Profile", description = "프로필 관련 API")
 public interface ProfileApi {
+
     @Operation(summary = "프로필 수정", description = "조직명, 이메일, 프로필 이미지를 선택적으로 수정합니다.")
-    void updateProfile(@Valid ProfileUpdateRequest dto, @Parameter(hidden = true)User user);
+    void updateProfile(
+            @Parameter(hidden = true) User user,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+            @RequestPart(value = "profile", required = false) @Valid ProfileUpdateRequest dto
+    );
+
+    @Operation(summary = "사용자 링크 재생성", description = "회원 UUID 기반 사용자 링크를 새로 발급합니다.")
+    void updateLink(
+            @Parameter(hidden = true) User user
+    );
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
@@ -3,6 +3,7 @@ package com.ClubAccount_BE.user.adapter.in.update;
 import com.ClubAccount_BE.core.meta.LoginUser;
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.LoginUserUpdatePassword;
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.response.UserProfileResponse;
 import com.ClubAccount_BE.user.application.port.in.update.ProfileUseCase;
 import com.ClubAccount_BE.user.domain.User;
 import jakarta.validation.Valid;
@@ -34,5 +35,10 @@ public class ProfileController implements ProfileApi {
     public void changePassword(@LoginUser User user,
                                @RequestBody @Valid LoginUserUpdatePassword request) {
         profileUseCase.changePassword(user, request.currentPassword(), request.newPassword());
+    }
+
+    @GetMapping
+    public UserProfileResponse getProfile(@LoginUser User user) {
+        return profileUseCase.getProfile(user);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
@@ -1,0 +1,24 @@
+package com.ClubAccount_BE.user.adapter.in.update;
+
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.application.port.in.update.ProfileUseCase;
+import com.ClubAccount_BE.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileUseCase profileUseCase;
+
+    @PatchMapping("/update")
+    public void updateProfile(@LoginUser User user,
+                              @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+                              @RequestPart(value = "profile", required = false) ProfileUpdateRequest profileDto) {
+        profileUseCase.updateProfile(user, profileImage, profileDto);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1/profile")
 @RequiredArgsConstructor
-public class ProfileController {
+public class ProfileController implements ProfileApi {
 
     private final ProfileUseCase profileUseCase;
 
@@ -20,5 +20,11 @@ public class ProfileController {
                               @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
                               @RequestPart(value = "profile", required = false) ProfileUpdateRequest profileDto) {
         profileUseCase.updateProfile(user, profileImage, profileDto);
+
+    }
+
+    @PatchMapping("/regenerate-link")
+    public void updateLink(@LoginUser User user) {
+        profileUseCase.updateLink(user);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/ProfileController.java
@@ -1,9 +1,11 @@
 package com.ClubAccount_BE.user.adapter.in.update;
 
 import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.LoginUserUpdatePassword;
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
 import com.ClubAccount_BE.user.application.port.in.update.ProfileUseCase;
 import com.ClubAccount_BE.user.domain.User;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,5 +28,11 @@ public class ProfileController implements ProfileApi {
     @PatchMapping("/regenerate-link")
     public void updateLink(@LoginUser User user) {
         profileUseCase.updateLink(user);
+    }
+
+    @PatchMapping("/password")
+    public void changePassword(@LoginUser User user,
+                               @RequestBody @Valid LoginUserUpdatePassword request) {
+        profileUseCase.changePassword(user, request.currentPassword(), request.newPassword());
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/LoginUserUpdatePassword.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/LoginUserUpdatePassword.java
@@ -1,0 +1,22 @@
+package com.ClubAccount_BE.user.adapter.in.update.dto.request;
+
+import com.ClubAccount_BE.core.meta.PasswordMatch;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@PasswordMatch
+public record LoginUserUpdatePassword(
+
+        @NotBlank(message = "기존 비밀번호는 필수입니다.")
+        @Schema(name = "currentPassword", example = "thinkboo1343!")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Schema(name = "newPassword", example = "newthinkboo1343!")
+        String newPassword,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
+        @Schema(name = "confirmPassword", example = "newthinkboo1343!")
+        String confirmPassword
+) {
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.ClubAccount_BE.user.adapter.in.update.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+
+public record ProfileUpdateRequest(
+
+        @Schema(name = "organization", example = "띵부")
+        String organization,
+
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Schema(name = "authId", example = "thinkboo@example.com")
+        String authId
+) {}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/in/update/dto/response/UserProfileResponse.java
@@ -1,0 +1,37 @@
+package com.ClubAccount_BE.user.adapter.in.update.dto.response;
+
+import com.ClubAccount_BE.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "사용자 프로필 응답")
+public record UserProfileResponse(
+
+        @Schema(description = "조직명", example = "띵부")
+        String department,
+
+        @Schema(description = "이메일", example = "thinkboo@example.com")
+        String email,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://cdn.example.com/images/profile.jpg")
+        String profileUrl,
+
+        @Schema(description = "공유 링크 UUID", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+        UUID link,
+
+        @Schema(description = "가입일", example = "2025-05-06T08:24:08.486Z")
+        Instant createdAt
+
+) {
+    public static UserProfileResponse from(User user) {
+        return new UserProfileResponse(
+                user.getDepartment(),
+                user.getAuthId(),
+                user.getProfileUrl(),
+                user.getLink(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/ProfileImageRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/ProfileImageRepositoryAdapter.java
@@ -1,0 +1,54 @@
+package com.ClubAccount_BE.user.adapter.out;
+
+import com.ClubAccount_BE.user.application.port.out.UploadProfileImagePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static com.ClubAccount_BE.core.constant.CommonConstant.IMAGE_KEY_DELIMITER;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileImageRepositoryAdapter implements UploadProfileImagePort {
+
+    private final S3Client amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String uploadProfileImage(Long userId, MultipartFile image) {
+
+        String imageName = createImageName(image.getOriginalFilename());
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(imageName)
+                    .contentType(image.getContentType())
+                    .build();
+
+            amazonS3.putObject(request,
+                    RequestBody.fromInputStream(image.getInputStream(), image.getSize())
+            );
+
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+
+        return amazonS3.utilities()
+                .getUrl(b -> b.bucket(bucket).key(imageName))
+                .toExternalForm();
+    }
+
+    private String createImageName(String originalFilename) {
+        return UUID.randomUUID() + IMAGE_KEY_DELIMITER + originalFilename;
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -5,7 +5,7 @@ import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
 import com.ClubAccount_BE.user.adapter.out.persistence.repository.UserRepository;
 import com.ClubAccount_BE.user.application.port.out.CheckUserPort;
 import com.ClubAccount_BE.user.application.port.out.FindUserPort;
-import com.ClubAccount_BE.user.application.port.out.SaveUserPort;
+import com.ClubAccount_BE.user.application.port.out.UserPort;
 import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
 import com.ClubAccount_BE.user.application.service.update.UpdatePasswordPort;
 import com.ClubAccount_BE.user.domain.User;
@@ -16,16 +16,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class UserPersistenceAdapter implements FindUserPort, SaveUserPort, CheckUserPort,
+public class UserPersistenceAdapter implements FindUserPort, UserPort, CheckUserPort,
         FindUserByEmailPort, UpdatePasswordPort, FindUserLinkPort {
 
     private final UserRepository userRepository;
 
     @Override
-    public User saveUser(User user) {
+    public void save(User user) {
         UserEntity entity = UserMapper.toEntity(user);
         UserEntity saved = userRepository.save(entity);
-        return UserMapper.toDomain(saved);
+        UserMapper.toDomain(saved);
     }
 
     @Override

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -7,7 +7,7 @@ import com.ClubAccount_BE.user.application.port.out.CheckUserPort;
 import com.ClubAccount_BE.user.application.port.out.FindUserPort;
 import com.ClubAccount_BE.user.application.port.out.UserPort;
 import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
-import com.ClubAccount_BE.user.application.service.update.UpdatePasswordPort;
+import com.ClubAccount_BE.user.application.port.out.update.UpdatePasswordPort;
 import com.ClubAccount_BE.user.domain.User;
 import com.ClubAccount_BE.user.mapper.UserMapper;
 import java.util.UUID;

--- a/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/ClubAccount_BE/user/adapter/out/persistence/entity/UserEntity.java
@@ -35,7 +35,7 @@ public class UserEntity extends TimeBaseEntity {
 
     private String profileUrl;
 
-    @Column(length = 36, nullable = false, unique = true, updatable = false)
+    @Column(length = 36, nullable = false, unique = true)
     @JdbcTypeCode(SqlTypes.CHAR)
     private UUID link;
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
@@ -1,0 +1,11 @@
+package com.ClubAccount_BE.user.application.port.in.update;
+
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.domain.User;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileUseCase {
+    //ProfileResponse getProfile(User user);
+    void updateProfile(User user, MultipartFile profileImage , ProfileUpdateRequest dto);
+    //void changePassword(User user, PasswordChangeRequest dto);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
@@ -1,6 +1,7 @@
 package com.ClubAccount_BE.user.application.port.in.update;
 
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.response.UserProfileResponse;
 import com.ClubAccount_BE.user.domain.User;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -10,4 +11,6 @@ public interface ProfileUseCase {
     void updateLink(User user);
 
     void changePassword(User user, String currentPassword, String newPassword);
+
+    UserProfileResponse getProfile(User user);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
@@ -8,5 +8,6 @@ public interface ProfileUseCase {
     void updateProfile(User user, MultipartFile profileImage , ProfileUpdateRequest dto);
 
     void updateLink(User user);
-    //void changePassword(User user, PasswordChangeRequest dto);
+
+    void changePassword(User user, String currentPassword, String newPassword);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/in/update/ProfileUseCase.java
@@ -5,7 +5,8 @@ import com.ClubAccount_BE.user.domain.User;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ProfileUseCase {
-    //ProfileResponse getProfile(User user);
     void updateProfile(User user, MultipartFile profileImage , ProfileUpdateRequest dto);
+
+    void updateLink(User user);
     //void changePassword(User user, PasswordChangeRequest dto);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/UploadProfileImagePort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/UploadProfileImagePort.java
@@ -1,0 +1,7 @@
+package com.ClubAccount_BE.user.application.port.out;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface UploadProfileImagePort {
+    String uploadProfileImage(Long userId, MultipartFile image);
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/UserPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/UserPort.java
@@ -2,6 +2,6 @@ package com.ClubAccount_BE.user.application.port.out;
 
 import com.ClubAccount_BE.user.domain.User;
 
-public interface SaveUserPort {
-    User saveUser(User user);
+public interface UserPort {
+    void save(User user);
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/port/out/update/UpdatePasswordPort.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/port/out/update/UpdatePasswordPort.java
@@ -1,4 +1,4 @@
-package com.ClubAccount_BE.user.application.service.update;
+package com.ClubAccount_BE.user.application.port.out.update;
 
 import com.ClubAccount_BE.user.domain.User;
 

--- a/src/main/java/com/ClubAccount_BE/user/application/service/signup/SignUpService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/signup/SignUpService.java
@@ -3,7 +3,7 @@ package com.ClubAccount_BE.user.application.service.signup;
 import com.ClubAccount_BE.user.application.port.in.signup.SignUpCommand;
 import com.ClubAccount_BE.user.application.port.in.signup.SignUpUseCase;
 import com.ClubAccount_BE.user.application.port.out.CheckUserPort;
-import com.ClubAccount_BE.user.application.port.out.SaveUserPort;
+import com.ClubAccount_BE.user.application.port.out.UserPort;
 import com.ClubAccount_BE.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,7 +16,7 @@ import static com.ClubAccount_BE.core.exception.ErrorCode.DUPLICATED_AUTHID;
 @Transactional
 @RequiredArgsConstructor
 public class SignUpService implements SignUpUseCase {
-    private final SaveUserPort saveUserPort;
+    private final UserPort userPort;
     private final CheckUserPort checkUserPort;
     private final PasswordEncoder passwordEncoder;
 
@@ -29,7 +29,7 @@ public class SignUpService implements SignUpUseCase {
                 encodedPassword,
                 signUpCommand.getOrganization()
         );
-        saveUserPort.saveUser(newUser);
+        userPort.save(newUser);
     }
     private void checkDuplicateUser(SignUpCommand signUpCommand) {
         if (checkUserPort.checkDuplicateAuthId(signUpCommand.getAuthId())) {

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/PasswordResetService.java
@@ -2,6 +2,7 @@ package com.ClubAccount_BE.user.application.service.update;
 
 import com.ClubAccount_BE.user.application.port.in.update.PasswordResetUseCase;
 import com.ClubAccount_BE.user.application.port.out.update.FindUserByEmailPort;
+import com.ClubAccount_BE.user.application.port.out.update.UpdatePasswordPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
@@ -1,0 +1,37 @@
+package com.ClubAccount_BE.user.application.service.update;
+
+import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.application.port.in.update.ProfileUseCase;
+import com.ClubAccount_BE.user.application.port.out.UploadProfileImagePort;
+import com.ClubAccount_BE.user.application.port.out.UserPort;
+import com.ClubAccount_BE.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService implements ProfileUseCase {
+
+    private final UploadProfileImagePort uploadProfileImagePort;
+    private final UserPort userPort;
+
+    @Override
+    public void updateProfile(User user, MultipartFile profileImage, ProfileUpdateRequest dto) {
+        if (dto != null) {
+            if (dto.organization() != null) {
+                user.updateDepartment(dto.organization());
+            }
+            if (dto.authId() != null) {
+                user.updateAuthId(dto.authId());
+            }
+        }
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String url = uploadProfileImagePort.uploadProfileImage(user.getId(), profileImage);
+            user.updateProfileUrl(url);
+        }
+
+        userPort.save(user);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
@@ -6,6 +6,7 @@ import com.ClubAccount_BE.user.application.port.out.UploadProfileImagePort;
 import com.ClubAccount_BE.user.application.port.out.UserPort;
 import com.ClubAccount_BE.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,6 +16,7 @@ public class ProfileService implements ProfileUseCase {
 
     private final UploadProfileImagePort uploadProfileImagePort;
     private final UserPort userPort;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public void updateProfile(User user, MultipartFile profileImage, ProfileUpdateRequest dto) {
@@ -38,6 +40,15 @@ public class ProfileService implements ProfileUseCase {
     @Override
     public void updateLink(User user) {
         user.updateLink();
+        userPort.save(user);
+    }
+
+    @Override
+    public void changePassword(User user, String currentPassword, String newPassword) {
+        if (!user.matchPassword(passwordEncoder, currentPassword)) {
+            throw new IllegalArgumentException("기존 비밀번호가 일치하지 않습니다.");
+        }
+        user.updatePassword(passwordEncoder.encode(newPassword));
         userPort.save(user);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
@@ -34,4 +34,10 @@ public class ProfileService implements ProfileUseCase {
 
         userPort.save(user);
     }
+
+    @Override
+    public void updateLink(User user) {
+        user.updateLink();
+        userPort.save(user);
+    }
 }

--- a/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
+++ b/src/main/java/com/ClubAccount_BE/user/application/service/update/ProfileService.java
@@ -1,6 +1,7 @@
 package com.ClubAccount_BE.user.application.service.update;
 
 import com.ClubAccount_BE.user.adapter.in.update.dto.request.ProfileUpdateRequest;
+import com.ClubAccount_BE.user.adapter.in.update.dto.response.UserProfileResponse;
 import com.ClubAccount_BE.user.application.port.in.update.ProfileUseCase;
 import com.ClubAccount_BE.user.application.port.out.UploadProfileImagePort;
 import com.ClubAccount_BE.user.application.port.out.UserPort;
@@ -17,6 +18,7 @@ public class ProfileService implements ProfileUseCase {
     private final UploadProfileImagePort uploadProfileImagePort;
     private final UserPort userPort;
     private final PasswordEncoder passwordEncoder;
+
 
     @Override
     public void updateProfile(User user, MultipartFile profileImage, ProfileUpdateRequest dto) {
@@ -50,5 +52,10 @@ public class ProfileService implements ProfileUseCase {
         }
         user.updatePassword(passwordEncoder.encode(newPassword));
         userPort.save(user);
+    }
+
+    @Override
+    public UserProfileResponse getProfile(User user) {
+        return UserProfileResponse.from(user);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/user/domain/User.java
+++ b/src/main/java/com/ClubAccount_BE/user/domain/User.java
@@ -13,9 +13,9 @@ import java.util.UUID;
 public class User {
 
     private final Long id;
-    private final String authId;
+    private String authId;
     private String password;
-    private final String department;
+    private String department;
     private String profileUrl;
     private UUID link;
     private final Instant createdAt;
@@ -57,4 +57,13 @@ public class User {
     public void updateProfileUrl(String profileUrl) {
         this.profileUrl = profileUrl;
     }
+
+    public void updateDepartment(String department) {
+        this.department = department;
+    }
+
+    public void updateAuthId(String authId) {
+        this.authId = authId;
+    }
+
 }

--- a/src/main/java/com/ClubAccount_BE/user/domain/User.java
+++ b/src/main/java/com/ClubAccount_BE/user/domain/User.java
@@ -50,8 +50,8 @@ public class User {
         this.password = encodedPassword;
     }
 
-    public void updateRink(UUID rink) {
-        this.link = rink;
+    public void updateLink() {
+        this.link = UUID.randomUUID();
     }
 
     public void updateProfileUrl(String profileUrl) {


### PR DESCRIPTION
## 📌 작업 개요
* 로그인 사용자의 마이페이지(프로필) 관련 기능 일괄 개발 및 리팩토링

---

## ✅ 작업 내용
1.	프로필 조회 기능 추가
	* 조직명, 이메일, 프로필 이미지 URL, 공유 링크(UUID), 가입일 반환
2.	프로필 수정 기능 구현
	* 조직명, 이메일, 프로필 이미지 수정 가능 (Multipart/form-data 방식)
3.	비밀번호 변경 기능 추가
	* 현재 비밀번호 확인 후 새로운 비밀번호로 변경
4.	공유 링크(UUID) 재발급 기능 추가
5.	Port 인터페이스 네이밍 및 패키지 구조 정리
	* UpdatePasswordPort, SaveUserPort → 패키지 이동 및 메서드명 개선 (save, updatePassword)
---


## 📂 리뷰 요구사항
* User 도메인 모델과 UserEntity 간 Mapper 구조가 현재 방식에 적절한지
* ProfileUseCase 내부 책임 분리 수준 적절성(너무 한번에 몰아놓음)
---

