### PR TITLE
[TB-27] 영수증 금액 검증에 따른 API 수정

### DIFF
--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptDetailResponse.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptDetailResponse.java
@@ -17,7 +17,7 @@ public record ReceiptDetailResponse(
         String etc,
         String receiptImageUrl,
         List<ReceiptItemResponse> receiptItems,
-        boolean isAmountMatched
+        boolean amountMatched
 ) {
 
     public static ReceiptDetailResponse of(Receipt receipt) {
@@ -30,7 +30,7 @@ public record ReceiptDetailResponse(
                 .etc(receipt.getEtc())
                 .receiptImageUrl(receipt.getReceiptImageUrl())
                 .receiptItems(ReceiptItemResponse.of(receipt.getReceiptItems()))
-                .isAmountMatched(receipt.isAmountMatched())
+                .amountMatched(receipt.isAmountMatched())
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptDetailResponse.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptDetailResponse.java
@@ -16,7 +16,8 @@ public record ReceiptDetailResponse(
         BigDecimal amount,
         String etc,
         String receiptImageUrl,
-        List<ReceiptItemResponse> receiptItems
+        List<ReceiptItemResponse> receiptItems,
+        boolean isAmountMatched
 ) {
 
     public static ReceiptDetailResponse of(Receipt receipt) {
@@ -29,6 +30,7 @@ public record ReceiptDetailResponse(
                 .etc(receipt.getEtc())
                 .receiptImageUrl(receipt.getReceiptImageUrl())
                 .receiptItems(ReceiptItemResponse.of(receipt.getReceiptItems()))
+                .isAmountMatched(receipt.isAmountMatched())
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptResponse.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptResponse.java
@@ -15,7 +15,7 @@ public record ReceiptResponse(
         BigDecimal amount,
         String etc,
         String receiptImageUrl,
-        boolean isAmountMatched
+        boolean amountMatched
 ) {
 
     public static ReceiptResponse of(Receipt receipt) {
@@ -27,7 +27,7 @@ public record ReceiptResponse(
                 .amount(receipt.getAmount())
                 .etc(receipt.getEtc())
                 .receiptImageUrl(receipt.getReceiptImageUrl())
-                .isAmountMatched(receipt.isAmountMatched())
+                .amountMatched(receipt.isAmountMatched())
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptResponse.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptResponse.java
@@ -14,7 +14,8 @@ public record ReceiptResponse(
         LocalDate date,
         BigDecimal amount,
         String etc,
-        String receiptImageUrl
+        String receiptImageUrl,
+        boolean isAmountMatched
 ) {
 
     public static ReceiptResponse of(Receipt receipt) {
@@ -26,6 +27,7 @@ public record ReceiptResponse(
                 .amount(receipt.getAmount())
                 .etc(receipt.getEtc())
                 .receiptImageUrl(receipt.getReceiptImageUrl())
+                .isAmountMatched(receipt.isAmountMatched())
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -10,6 +10,7 @@ import com.ClubAccount_BE.receipt.application.port.out.FindReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.UpdateReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import com.ClubAccount_BE.receipt.mapper.ReceiptItemMapper;
 import com.ClubAccount_BE.receipt.mapper.ReceiptMapper;
 import com.ClubAccount_BE.user.domain.User;
 import java.time.LocalDate;
@@ -29,7 +30,9 @@ public class ReceiptRepositoryAdapter
     @Override
     public Long createReceipt(Receipt receipt, List<ReceiptItem> receiptItems) {
         ReceiptEntity receiptEntity = ReceiptMapper.toEntity(receipt);
-        receiptEntity.replaceReceiptItem(receiptItems);
+        receiptItems.stream()
+                .map(ReceiptItemMapper::toEntity)
+                .forEach(receiptEntity::addReceiptItem);
         return receiptRepository
                 .save(receiptEntity)
                 .getId();
@@ -74,7 +77,9 @@ public class ReceiptRepositoryAdapter
                 .orElseThrow(() -> new ApiException(RECEIPT_NOT_FOUND));
 
         receiptEntity.updateReceipt(receipt);
-        receiptEntity.replaceReceiptItem(receiptItems);
+        receiptItems.stream()
+                .map(ReceiptItemMapper::toEntity)
+                .forEach(receiptEntity::addReceiptItem);
         return receiptEntity.getId();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
@@ -60,7 +60,7 @@ public class ReceiptEntity extends TimeBaseEntity {
     private String receiptImageUrl;
 
     @Column(nullable = false)
-    private boolean isAmountMatched;
+    private boolean amountMatched;
 
     @Builder.Default
     @OneToMany(mappedBy = "receipt", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
@@ -61,6 +61,9 @@ public class ReceiptEntity extends TimeBaseEntity {
 
     private String receiptImageUrl;
 
+    @Column(nullable = false)
+    private boolean isAmountMatched;
+
     @Builder.Default
     @OneToMany(mappedBy = "receipt", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReceiptItemEntity> receiptItems = new ArrayList<>();

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/entity/ReceiptEntity.java
@@ -2,9 +2,7 @@ package com.ClubAccount_BE.receipt.adapter.out.persistence.entity;
 
 import com.ClubAccount_BE.core.entity.TimeBaseEntity;
 import com.ClubAccount_BE.receipt.domain.Receipt;
-import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
-import com.ClubAccount_BE.receipt.mapper.ReceiptItemMapper;
 import com.ClubAccount_BE.user.adapter.out.persistence.entity.UserEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -74,6 +72,7 @@ public class ReceiptEntity extends TimeBaseEntity {
         this.amount = receipt.getAmount();
         this.date = receipt.getDate();
         this.etc = receipt.getEtc();
+        this.receiptItems.clear();
     }
 
     public void addReceiptItem(ReceiptItemEntity receiptItem) {
@@ -81,12 +80,5 @@ public class ReceiptEntity extends TimeBaseEntity {
         if (receiptItem.getReceipt() != this) {
             receiptItem.addReceipt(this);
         }
-    }
-
-    public void replaceReceiptItem(List<ReceiptItem> receiptItems) {
-        this.receiptItems.clear();
-        receiptItems.stream()
-                .map(ReceiptItemMapper::toEntity)
-                .forEach(this::addReceiptItem);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
@@ -8,6 +8,7 @@ import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
 import com.ClubAccount_BE.receipt.domain.service.ReceiptItemEditor;
 import com.ClubAccount_BE.user.domain.User;
 import java.util.List;
@@ -22,9 +23,8 @@ import org.springframework.web.multipart.MultipartFile;
 public class CreateReceiptService implements CreateReceiptUseCase {
 
     private final CreateReceiptPort createReceiptPort;
-
     private final UploadReceiptPort uploadReceiptPort;
-
+    private final ReceiptEditor receiptEditor;
     private final ReceiptItemEditor receiptItemEditor;
 
     @Override
@@ -33,7 +33,6 @@ public class CreateReceiptService implements CreateReceiptUseCase {
             MultipartFile image,
             ReceiptRequest receiptRequest
     ) {
-
         Receipt receipt = Receipt.create(
                 user,
                 receiptRequest.category(),
@@ -43,8 +42,9 @@ public class CreateReceiptService implements CreateReceiptUseCase {
                 receiptRequest.etc(),
                 image == null ? DEFAULT_IMAGE : uploadReceiptPort.uploadReceipt(image)
         );
-
         List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
+        boolean isAmountMatched = receiptEditor.checkAmountMatch(receipt, receiptItems);
+        receipt.checkAmountMatched(isAmountMatched);
         return createReceiptPort.createReceipt(receipt, receiptItems);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
@@ -44,7 +44,7 @@ public class CreateReceiptService implements CreateReceiptUseCase {
         );
         List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
         boolean isAmountMatched = receiptEditor.checkAmountMatch(receipt, receiptItems);
-        receipt.checkAmountMatched(isAmountMatched);
+        receipt.updateAmountMatched(isAmountMatched);
         return createReceiptPort.createReceipt(receipt, receiptItems);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
@@ -40,7 +40,7 @@ public class UpdateReceiptService implements UpdateReceiptUseCase {
 
         List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
         boolean isAmountMatched = receiptEditor.checkAmountMatch(receipt, receiptItems);
-        receipt.checkAmountMatched(isAmountMatched);
+        receipt.updateAmountMatched(isAmountMatched);
         return updateReceiptPort.updateReceipt(receiptId, receipt, receiptItems);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/UpdateReceiptService.java
@@ -5,6 +5,7 @@ import com.ClubAccount_BE.receipt.application.port.in.UpdateReceiptUseCase;
 import com.ClubAccount_BE.receipt.application.port.out.UpdateReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
+import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
 import com.ClubAccount_BE.receipt.domain.service.ReceiptItemEditor;
 import com.ClubAccount_BE.user.domain.User;
 import java.util.List;
@@ -18,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateReceiptService implements UpdateReceiptUseCase {
 
     private final UpdateReceiptPort updateReceiptPort;
-
+    private final ReceiptEditor receiptEditor;
     private final ReceiptItemEditor receiptItemEditor;
 
     @Override
@@ -38,6 +39,8 @@ public class UpdateReceiptService implements UpdateReceiptUseCase {
         );
 
         List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
+        boolean isAmountMatched = receiptEditor.checkAmountMatch(receipt, receiptItems);
+        receipt.checkAmountMatched(isAmountMatched);
         return updateReceiptPort.updateReceipt(receiptId, receipt, receiptItems);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
@@ -87,7 +87,7 @@ public class Receipt {
                 .build();
     }
 
-    public void checkAmountMatched(boolean isAmountMatched) {
+    public void updateAmountMatched(boolean isAmountMatched) {
         this.isAmountMatched = isAmountMatched;
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
@@ -20,6 +20,7 @@ public class Receipt {
     private final String etc;
     private final String receiptImageUrl;
     private final List<ReceiptItem> receiptItems;
+    private boolean isAmountMatched;
 
     @Builder
     private Receipt(
@@ -31,7 +32,8 @@ public class Receipt {
             BigDecimal amount,
             String etc,
             String receiptImageUrl,
-            List<ReceiptItem> receiptItems
+            List<ReceiptItem> receiptItems,
+            boolean isAmountMatched
     ) {
         this.id = id;
         this.user = user;
@@ -42,6 +44,7 @@ public class Receipt {
         this.etc = etc;
         this.receiptImageUrl = receiptImageUrl;
         this.receiptItems = receiptItems;
+        this.isAmountMatched = isAmountMatched;
     }
 
     public static Receipt create(
@@ -82,5 +85,9 @@ public class Receipt {
                 .date(date)
                 .etc(etc)
                 .build();
+    }
+
+    public void checkAmountMatched(boolean isAmountMatched) {
+        this.isAmountMatched = isAmountMatched;
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/Receipt.java
@@ -20,7 +20,7 @@ public class Receipt {
     private final String etc;
     private final String receiptImageUrl;
     private final List<ReceiptItem> receiptItems;
-    private boolean isAmountMatched;
+    private boolean amountMatched;
 
     @Builder
     private Receipt(
@@ -33,7 +33,7 @@ public class Receipt {
             String etc,
             String receiptImageUrl,
             List<ReceiptItem> receiptItems,
-            boolean isAmountMatched
+            boolean amountMatched
     ) {
         this.id = id;
         this.user = user;
@@ -44,7 +44,7 @@ public class Receipt {
         this.etc = etc;
         this.receiptImageUrl = receiptImageUrl;
         this.receiptItems = receiptItems;
-        this.isAmountMatched = isAmountMatched;
+        this.amountMatched = amountMatched;
     }
 
     public static Receipt create(
@@ -87,7 +87,7 @@ public class Receipt {
                 .build();
     }
 
-    public void updateAmountMatched(boolean isAmountMatched) {
-        this.isAmountMatched = isAmountMatched;
+    public void updateAmountMatched(boolean amountMatched) {
+        this.amountMatched = amountMatched;
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
@@ -2,7 +2,9 @@ package com.ClubAccount_BE.receipt.domain.service;
 
 import com.ClubAccount_BE.receipt.domain.DetailCategoryResult;
 import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -10,6 +12,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ReceiptEditor {
+
+    /**
+     * 영수증 금액과 영수증 아이템 금액 비교
+     */
+    public boolean checkAmountMatch(Receipt receipt, List<ReceiptItem> items) {
+        BigDecimal total = items.stream()
+                .map(ReceiptItem::getTotalPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return total.compareTo(receipt.getAmount()) == 0;
+    }
 
     /**
      * 영수증 카테고리 비율 계산

--- a/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
@@ -16,7 +16,7 @@ public class ReceiptMapper {
                 .date(receipt.getDate())
                 .etc(receipt.getEtc())
                 .receiptImageUrl(receipt.getReceiptImageUrl())
-                .isAmountMatched(receipt.isAmountMatched())
+                .amountMatched(receipt.isAmountMatched())
                 .build();
     }
 
@@ -34,7 +34,7 @@ public class ReceiptMapper {
                         .map(ReceiptItemMapper::toDomain)
                         .toList()
                 )
-                .isAmountMatched(receiptEntity.isAmountMatched())
+                .amountMatched(receiptEntity.isAmountMatched())
                 .build();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/mapper/ReceiptMapper.java
@@ -15,7 +15,9 @@ public class ReceiptMapper {
                 .amount(receipt.getAmount())
                 .date(receipt.getDate())
                 .etc(receipt.getEtc())
-                .receiptImageUrl(receipt.getReceiptImageUrl()).build();
+                .receiptImageUrl(receipt.getReceiptImageUrl())
+                .isAmountMatched(receipt.isAmountMatched())
+                .build();
     }
 
     public static Receipt toDomain(ReceiptEntity receiptEntity) {
@@ -32,6 +34,7 @@ public class ReceiptMapper {
                         .map(ReceiptItemMapper::toDomain)
                         .toList()
                 )
+                .isAmountMatched(receiptEntity.isAmountMatched())
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
* 영수증에 기재된 금액과 영수증 구매 내역 리스트의 가격 총합을 비교하여 일치하는 지에 대한 로직 추가 

---

## ✅ 작업 내용
1. Receipt 엔티티 필드 추가 
2. 비즈니스 도메인 서비스단에서 금액 검증 로직 (영수증 등록과 수정할 경우)
3. 영수증 조회 시에 일치하는 지에 대한 여부 반환

---

## 📂 리뷰 요구사항
- 현재 설계된 아키텍쳐 흐름 상 비교 로직에 대해 적절하게 구현되었는지 리뷰 부탁드립니다.
---

