### PR TITLE
[TB-28] 영수증 월별 지출액 조회 API 구현

### DIFF
--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/FindReceiptController.java
@@ -4,9 +4,12 @@ import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.api.FindReceiptApi;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptExpenseResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import com.ClubAccount_BE.receipt.application.port.in.FindReceiptUseCase;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -49,5 +52,13 @@ public class FindReceiptController implements FindReceiptApi {
             @PathVariable(value = "link") UUID link
     ) {
         return findReceiptUseCase.getReceiptCategoryRatio(link);
+    }
+
+    @GetMapping("/{link}/receipts/expense")
+    public List<ReceiptExpenseResponse> getReceiptExpenseList(
+            @PathVariable(value = "link") UUID link,
+            @Positive(message = "유효하지 않은 연도입니다.") @RequestParam int year
+    ) {
+        return findReceiptUseCase.getReceiptExpenseList(link, year);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/FindReceiptApi.java
@@ -3,10 +3,13 @@ package com.ClubAccount_BE.receipt.adapter.in.web.api;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptExpenseResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -38,5 +41,11 @@ public interface FindReceiptApi {
     @Operation(summary = "영수증 카테고리 비율 조회", description = "등록된 영수증의 카테고리 비율을 조회한다.")
     ReceiptCategoryResponse getReceiptCategoryRatio(
             @PathVariable(value = "link") UUID link
+    );
+
+    @Operation(summary = "영수증 월별 지출 목록 조회", description = "등록된 영수증의 월별 지출을 조회한다.")
+    List<ReceiptExpenseResponse> getReceiptExpenseList(
+            @PathVariable(value = "link") UUID link,
+            @Positive(message = "유효하지 않은 연도입니다.") @RequestParam int year
     );
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptExpenseResponse.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/dto/response/ReceiptExpenseResponse.java
@@ -1,0 +1,24 @@
+package com.ClubAccount_BE.receipt.adapter.in.web.dto.response;
+
+import com.ClubAccount_BE.receipt.domain.DetailExpenseResult;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ReceiptExpenseResponse(
+        UUID id,
+        int year,
+        int month,
+        BigDecimal totalExpense
+) {
+
+    public static ReceiptExpenseResponse of(DetailExpenseResult result) {
+        return ReceiptExpenseResponse.builder()
+                .id(UUID.nameUUIDFromBytes((result.getYear() + "-" + result.getMonth()).getBytes()))
+                .year(result.getYear())
+                .month(result.getMonth())
+                .totalExpense(result.getTotalExpense())
+                .build();
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -59,6 +59,15 @@ public class ReceiptRepositoryAdapter
     }
 
     @Override
+    public List<Receipt> getReceiptExpenseList(User user, int year) {
+        return receiptRepository
+                .findByUserIdAndYear(user.getId(), year)
+                .stream()
+                .map(ReceiptMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public List<Receipt> getReceiptCategoryList(User user) {
         return receiptRepository
                 .findAllByUserId(user.getId())

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepository.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepository.java
@@ -2,6 +2,7 @@ package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
 
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,4 +14,6 @@ public interface ReceiptCustomRepository {
             LocalDate endDate,
             Pageable pageable
     );
+
+    List<ReceiptEntity> findByUserIdAndYear(Long userId, int year);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/persistence/repository/ReceiptCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ClubAccount_BE.receipt.adapter.out.persistence.repository;
 
-import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.QReceiptEntity;
+import static com.ClubAccount_BE.receipt.adapter.out.persistence.entity.QReceiptEntity.receiptEntity;
+
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
@@ -24,28 +25,38 @@ public class ReceiptCustomRepositoryImpl implements ReceiptCustomRepository {
             LocalDate endDate,
             Pageable pageable
     ) {
-        QReceiptEntity receipt = QReceiptEntity.receiptEntity;
 
         BooleanBuilder where = new BooleanBuilder();
-        where.and(receipt.user.id.eq(userId));
+        where.and(receiptEntity.user.id.eq(userId));
 
         if (startDate != null && endDate != null) {
-            where.and(receipt.date.between(startDate, endDate));
+            where.and(receiptEntity.date.between(startDate, endDate));
         }
 
         List<ReceiptEntity> content = queryFactory
-                .selectFrom(receipt)
+                .selectFrom(receiptEntity)
                 .where(where)
-                .orderBy(receipt.date.desc())
+                .orderBy(receiptEntity.date.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Long> count = queryFactory
-                .select(receipt.count())
-                .from(receipt)
+                .select(receiptEntity.count())
+                .from(receiptEntity)
                 .where(where);
 
         return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+    }
+
+    @Override
+    public List<ReceiptEntity> findByUserIdAndYear(Long userId, int year) {
+        return queryFactory
+                .selectFrom(receiptEntity)
+                .where(
+                        receiptEntity.user.id.eq(userId),
+                        receiptEntity.date.year().eq(year)
+                )
+                .fetch();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/FindReceiptUseCase.java
@@ -3,8 +3,10 @@ package com.ClubAccount_BE.receipt.application.port.in;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptExpenseResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
@@ -20,4 +22,6 @@ public interface FindReceiptUseCase {
     );
 
     ReceiptDetailResponse getReceipt(UUID link, Long receiptId);
+
+    List<ReceiptExpenseResponse> getReceiptExpenseList(UUID link, int year);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/FindReceiptPort.java
@@ -19,4 +19,6 @@ public interface FindReceiptPort {
     List<Receipt> getReceiptCategoryList(User user);
 
     Receipt getReceipt(User user, Long receiptId);
+
+    List<Receipt> getReceiptExpenseList(User user, int year);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/FindReceiptService.java
@@ -6,10 +6,12 @@ import com.ClubAccount_BE.core.exception.ApiException;
 import com.ClubAccount_BE.core.response.PagingResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptCategoryResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptDetailResponse;
+import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptExpenseResponse;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.response.ReceiptResponse;
 import com.ClubAccount_BE.receipt.application.port.in.FindReceiptUseCase;
 import com.ClubAccount_BE.receipt.application.port.out.FindReceiptPort;
 import com.ClubAccount_BE.receipt.domain.DetailCategoryResult;
+import com.ClubAccount_BE.receipt.domain.DetailExpenseResult;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
 import com.ClubAccount_BE.user.application.port.out.FindUserPort;
@@ -38,6 +40,17 @@ public class FindReceiptService implements FindReceiptUseCase {
         User user = findUserPort.getUserByLink(link);
         Receipt receipt = findReceiptPort.getReceipt(user, receiptId);
         return ReceiptDetailResponse.of(receipt);
+    }
+
+    @Override
+    public List<ReceiptExpenseResponse> getReceiptExpenseList(UUID link, int year) {
+
+        User user = findUserPort.getUserByLink(link);
+        List<Receipt> receiptList = findReceiptPort.getReceiptExpenseList(user, year);
+        List<DetailExpenseResult> results = receiptEditor.calculateExpense(receiptList, year);
+        return results.stream()
+                .map(ReceiptExpenseResponse::of)
+                .toList();
     }
 
 

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/DetailExpenseResult.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/DetailExpenseResult.java
@@ -1,0 +1,28 @@
+package com.ClubAccount_BE.receipt.domain;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DetailExpenseResult {
+
+    private final int year;
+    private final int month;
+    private final BigDecimal totalExpense;
+
+    @Builder
+    private DetailExpenseResult(int year, int month, BigDecimal totalExpense) {
+        this.year = year;
+        this.month = month;
+        this.totalExpense = totalExpense;
+    }
+
+    public static DetailExpenseResult of(int year, int month, BigDecimal totalExpense) {
+        return DetailExpenseResult.builder()
+                .year(year)
+                .month(month)
+                .totalExpense(totalExpense)
+                .build();
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
@@ -1,6 +1,7 @@
 package com.ClubAccount_BE.receipt.domain.service;
 
 import com.ClubAccount_BE.receipt.domain.DetailCategoryResult;
+import com.ClubAccount_BE.receipt.domain.DetailExpenseResult;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.domain.type.ReceiptCategory;
@@ -8,6 +9,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -44,6 +46,24 @@ public class ReceiptEditor {
                 ratio(counts.get(ReceiptCategory.VENUE_RENTAL), total),
                 ratio(counts.get(ReceiptCategory.OTHER), total)
         );
+    }
+
+    /**
+     * 영수증 월별 지출 계산
+     */
+    public List<DetailExpenseResult> calculateExpense(List<Receipt> receiptList, int year) {
+        Map<Integer, BigDecimal> monthlyExpense = receiptList.stream()
+                .collect(Collectors.groupingBy(
+                        receipt -> receipt.getDate().getMonthValue(),
+                        Collectors.reducing(BigDecimal.ZERO, Receipt::getAmount, BigDecimal::add)
+                ));
+
+        return IntStream.rangeClosed(1, 12)
+                .mapToObj(month -> DetailExpenseResult.of(
+                        year,
+                        month,
+                        monthlyExpense.getOrDefault(month, BigDecimal.ZERO)))
+                .collect(Collectors.toList());
     }
 
     private float ratio(Long count, int total) {


### PR DESCRIPTION
## 📌 작업 개요
* 해당 조직에 지출된 금액을 월별로 조회가 가능하도록 구현

---

## ✅ 작업 내용
1. 비즈니스 도메인 서비스 로직에서 지출된 금액을 월별로 그룹으로 묶어 `DetailExpenseResult` 반환
2. 프론트 요구사항에 맞춰 각 응답값에 따른 고유 UUID 반환
    * 이는 년도와 월별에 따른 UUID 값 생성으로 호출 시 값이 변경되지 않습니다.

---

## 📂 리뷰 요구사항
- 현재 UseCase 분리가 필요할 듯 하여 추후 리팩토링을 통해 도메인과 유스케이스를 분리할 예정입니다.
- 추가로 Copilot이 단 nitPick의 경우 영수증 승인일시는 YYYY-MM 포맷팅 형식으로 DB에 저장되어 있어 별도의 값 반환시 포맷팅 설정이 불필요하다고 판단하여 추가하지 않았습니다.

---

