### PR TITLE
[TB-33] 영수증 삭제 API 기능 구현

### DIFF
--- a/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
+++ b/src/main/java/com/ClubAccount_BE/core/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     // 영수증 관련 에러 코드
     RECEIPT_INVALID_START_DATE("2001", "시작일은 종료일보다 빠르거나 같아야 합니다.", HttpStatus.BAD_REQUEST),
     RECEIPT_NOT_FOUND("2002", "해당 영수증을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    RECEIPT_NOT_DELETE("2003", "요청한 영수증을 삭제할 수 없습니다.", HttpStatus.FORBIDDEN),
 
     // S3 관련 에러 코드
     S3_UPLOAD_FAIL("3001", "S3에 이미지 업로드 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/ClubAccount_BE/core/meta/LoginUser.java
+++ b/src/main/java/com/ClubAccount_BE/core/meta/LoginUser.java
@@ -1,5 +1,6 @@
 package com.ClubAccount_BE.core.meta;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,6 +10,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Parameter(hidden = true)
 public @interface LoginUser {
 
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/CreateReceiptController.java
@@ -20,7 +20,7 @@ public class CreateReceiptController implements CreateReceiptApi {
 
     private final CreateReceiptUseCase createReceiptUseCase;
 
-    @PostMapping("/create")
+    @PostMapping
     public Long createReceipt(
             @LoginUser User user,
             @RequestPart(value = "image", required = false) MultipartFile image,

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
@@ -1,0 +1,31 @@
+package com.ClubAccount_BE.receipt.adapter.in.web;
+
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.receipt.adapter.in.web.api.DeleteReceiptApi;
+import com.ClubAccount_BE.receipt.application.port.in.DeleteReceiptUseCase;
+import com.ClubAccount_BE.user.domain.User;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/receipts")
+public class DeleteReceiptController implements DeleteReceiptApi {
+
+    private final DeleteReceiptUseCase deleteReceiptUseCase;
+
+    @DeleteMapping("/receipts")
+    public ResponseEntity<Void> deleteReceiptList(
+            @LoginUser User user,
+            @NotEmpty @RequestParam List<Long> receiptIds
+    ) {
+        deleteReceiptUseCase.deleteReceiptList(user, receiptIds);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
@@ -23,7 +23,7 @@ public class DeleteReceiptController implements DeleteReceiptApi {
     @DeleteMapping("/receipts")
     public ResponseEntity<Void> deleteReceiptList(
             @LoginUser User user,
-            @NotEmpty @RequestParam List<Long> receiptIds
+            @RequestParam @NotEmpty List<Long> receiptIds
     ) {
         deleteReceiptUseCase.deleteReceiptList(user, receiptIds);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/DeleteReceiptController.java
@@ -20,7 +20,7 @@ public class DeleteReceiptController implements DeleteReceiptApi {
 
     private final DeleteReceiptUseCase deleteReceiptUseCase;
 
-    @DeleteMapping("/receipts")
+    @DeleteMapping
     public ResponseEntity<Void> deleteReceiptList(
             @LoginUser User user,
             @RequestParam @NotEmpty List<Long> receiptIds

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/DeleteReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/DeleteReceiptApi.java
@@ -15,6 +15,6 @@ public interface DeleteReceiptApi {
     @Operation(summary = "영수증 삭제", description = "등록된 영수증 정보를 삭제한다.")
     ResponseEntity<Void> deleteReceiptList(
             @LoginUser User user,
-            @NotEmpty @RequestParam List<Long> receiptIds
+            @RequestParam @NotEmpty List<Long> receiptIds
     );
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/DeleteReceiptApi.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/in/web/api/DeleteReceiptApi.java
@@ -1,0 +1,20 @@
+package com.ClubAccount_BE.receipt.adapter.in.web.api;
+
+import com.ClubAccount_BE.core.meta.LoginUser;
+import com.ClubAccount_BE.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Delete Receipt", description = "영수증 삭제 API")
+public interface DeleteReceiptApi {
+
+    @Operation(summary = "영수증 삭제", description = "등록된 영수증 정보를 삭제한다.")
+    ResponseEntity<Void> deleteReceiptList(
+            @LoginUser User user,
+            @NotEmpty @RequestParam List<Long> receiptIds
+    );
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptImageRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptImageRepositoryAdapter.java
@@ -1,12 +1,14 @@
 package com.ClubAccount_BE.receipt.adapter.out;
 
-
 import static com.ClubAccount_BE.core.constant.CommonConstant.IMAGE_KEY_DELIMITER;
 import static com.ClubAccount_BE.core.exception.ErrorCode.S3_UPLOAD_FAIL;
 
 import com.ClubAccount_BE.core.exception.ApiException;
+import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptImagePort;
 import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
 import java.io.IOException;
+import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,11 +16,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
 @RequiredArgsConstructor
-public class ReceiptImageRepositoryAdapter implements UploadReceiptPort {
+public class ReceiptImageRepositoryAdapter implements UploadReceiptPort, DeleteReceiptImagePort {
 
     private final S3Client amazonS3;
 
@@ -48,6 +51,19 @@ public class ReceiptImageRepositoryAdapter implements UploadReceiptPort {
         return getImageUrl(imageName);
     }
 
+    // TODO: S3에서 이미지 삭제 로직 비동기 처리
+    @Override
+    public void deleteImages(List<String> receiptImage) {
+        receiptImage.forEach(url -> {
+            String key = extractKey(url);
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            amazonS3.deleteObject(request);
+        });
+    }
+
     private String createImageName(String originalFilename) {
         return UUID.randomUUID() + IMAGE_KEY_DELIMITER + originalFilename;
     }
@@ -56,5 +72,9 @@ public class ReceiptImageRepositoryAdapter implements UploadReceiptPort {
         return amazonS3.utilities()
                 .getUrl(builder -> builder.bucket(bucket).key(fileName))
                 .toExternalForm();
+    }
+
+    private String extractKey(String url) {
+        return URI.create(url).getPath().substring(1);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptImageRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptImageRepositoryAdapter.java
@@ -5,7 +5,7 @@ import static com.ClubAccount_BE.core.exception.ErrorCode.S3_UPLOAD_FAIL;
 
 import com.ClubAccount_BE.core.exception.ApiException;
 import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptImagePort;
-import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
+import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptImagePort;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -21,7 +21,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
 @RequiredArgsConstructor
-public class ReceiptImageRepositoryAdapter implements UploadReceiptPort, DeleteReceiptImagePort {
+public class ReceiptImageRepositoryAdapter implements UploadReceiptImagePort, DeleteReceiptImagePort {
 
     private final S3Client amazonS3;
 

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -1,11 +1,13 @@
 package com.ClubAccount_BE.receipt.adapter.out;
 
+import static com.ClubAccount_BE.core.exception.ErrorCode.RECEIPT_NOT_DELETE;
 import static com.ClubAccount_BE.core.exception.ErrorCode.RECEIPT_NOT_FOUND;
 
 import com.ClubAccount_BE.core.exception.ApiException;
 import com.ClubAccount_BE.receipt.adapter.out.persistence.entity.ReceiptEntity;
 import com.ClubAccount_BE.receipt.adapter.out.persistence.repository.ReceiptRepository;
 import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
+import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.FindReceiptPort;
 import com.ClubAccount_BE.receipt.application.port.out.UpdateReceiptPort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
@@ -23,7 +25,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class ReceiptRepositoryAdapter
-        implements CreateReceiptPort, FindReceiptPort, UpdateReceiptPort {
+        implements CreateReceiptPort, FindReceiptPort, UpdateReceiptPort, DeleteReceiptPort {
 
     private final ReceiptRepository receiptRepository;
 
@@ -90,5 +92,19 @@ public class ReceiptRepositoryAdapter
                 .map(ReceiptItemMapper::toEntity)
                 .forEach(receiptEntity::addReceiptItem);
         return receiptEntity.getId();
+    }
+
+    @Override
+    public void deleteReceiptList(User user, List<Long> receiptIds) {
+        List<ReceiptEntity> receipts = receiptRepository.findAllById(receiptIds);
+
+        boolean hasInvalidOwner = receipts.stream()
+                .anyMatch(receipt -> !receipt.getUser().getId().equals(user.getId()));
+
+        if (hasInvalidOwner || receipts.size() != receiptIds.size()) {
+            throw new ApiException(RECEIPT_NOT_DELETE);
+        }
+
+        receiptRepository.deleteAll(receipts);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/adapter/out/ReceiptRepositoryAdapter.java
@@ -95,7 +95,7 @@ public class ReceiptRepositoryAdapter
     }
 
     @Override
-    public void deleteReceiptList(User user, List<Long> receiptIds) {
+    public List<Receipt> deleteReceiptList(User user, List<Long> receiptIds) {
         List<ReceiptEntity> receipts = receiptRepository.findAllById(receiptIds);
 
         boolean hasInvalidOwner = receipts.stream()
@@ -106,5 +106,6 @@ public class ReceiptRepositoryAdapter
         }
 
         receiptRepository.deleteAll(receipts);
+        return receipts.stream().map(ReceiptMapper::toDomain).toList();
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/in/DeleteReceiptUseCase.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/in/DeleteReceiptUseCase.java
@@ -1,0 +1,9 @@
+package com.ClubAccount_BE.receipt.application.port.in;
+
+import com.ClubAccount_BE.user.domain.User;
+import java.util.List;
+
+public interface DeleteReceiptUseCase {
+
+    void deleteReceiptList(User user, List<Long> receiptIds);
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptImagePort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptImagePort.java
@@ -1,0 +1,8 @@
+package com.ClubAccount_BE.receipt.application.port.out;
+
+import java.util.List;
+
+public interface DeleteReceiptImagePort {
+
+    void deleteImages(List<String> receiptImage);
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
@@ -7,5 +7,4 @@ import java.util.List;
 public interface DeleteReceiptPort {
 
     List<Receipt> deleteReceiptList(User user, List<Long> receiptIds);
-
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
@@ -1,10 +1,11 @@
 package com.ClubAccount_BE.receipt.application.port.out;
 
+import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.user.domain.User;
 import java.util.List;
 
 public interface DeleteReceiptPort {
 
-    void deleteReceiptList(User user, List<Long> receiptIds);
+    List<Receipt> deleteReceiptList(User user, List<Long> receiptIds);
 
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/DeleteReceiptPort.java
@@ -1,0 +1,10 @@
+package com.ClubAccount_BE.receipt.application.port.out;
+
+import com.ClubAccount_BE.user.domain.User;
+import java.util.List;
+
+public interface DeleteReceiptPort {
+
+    void deleteReceiptList(User user, List<Long> receiptIds);
+
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/application/port/out/UploadReceiptImagePort.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/port/out/UploadReceiptImagePort.java
@@ -2,7 +2,7 @@ package com.ClubAccount_BE.receipt.application.port.out;
 
 import org.springframework.web.multipart.MultipartFile;
 
-public interface UploadReceiptPort {
+public interface UploadReceiptImagePort {
 
     String uploadReceipt(MultipartFile image);
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptService.java
@@ -5,7 +5,7 @@ import static com.ClubAccount_BE.core.constant.CommonConstant.DEFAULT_IMAGE;
 import com.ClubAccount_BE.receipt.adapter.in.web.dto.request.ReceiptRequest;
 import com.ClubAccount_BE.receipt.application.port.in.CreateReceiptUseCase;
 import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
-import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
+import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptImagePort;
 import com.ClubAccount_BE.receipt.domain.Receipt;
 import com.ClubAccount_BE.receipt.domain.ReceiptItem;
 import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
@@ -23,7 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class CreateReceiptService implements CreateReceiptUseCase {
 
     private final CreateReceiptPort createReceiptPort;
-    private final UploadReceiptPort uploadReceiptPort;
+    private final UploadReceiptImagePort uploadReceiptImagePort;
     private final ReceiptEditor receiptEditor;
     private final ReceiptItemEditor receiptItemEditor;
 
@@ -40,7 +40,7 @@ public class CreateReceiptService implements CreateReceiptUseCase {
                 receiptRequest.date(),
                 receiptRequest.amount(),
                 receiptRequest.etc(),
-                image == null ? DEFAULT_IMAGE : uploadReceiptPort.uploadReceipt(image)
+                image == null ? DEFAULT_IMAGE : uploadReceiptImagePort.uploadReceipt(image)
         );
         List<ReceiptItem> receiptItems = receiptItemEditor.toReceiptItems(receiptRequest, receipt);
         boolean isAmountMatched = receiptEditor.checkAmountMatch(receipt, receiptItems);

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/DeleteReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/DeleteReceiptService.java
@@ -1,7 +1,10 @@
 package com.ClubAccount_BE.receipt.application.service;
 
 import com.ClubAccount_BE.receipt.application.port.in.DeleteReceiptUseCase;
+import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptImagePort;
 import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptPort;
+import com.ClubAccount_BE.receipt.domain.Receipt;
+import com.ClubAccount_BE.receipt.domain.service.ReceiptEditor;
 import com.ClubAccount_BE.user.domain.User;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeleteReceiptService implements DeleteReceiptUseCase {
 
     private final DeleteReceiptPort deleteReceiptPort;
+    private final DeleteReceiptImagePort deleteReceiptImagePort;
+    private final ReceiptEditor receiptEditor;
 
     @Override
     public void deleteReceiptList(User user, List<Long> receiptIds) {
-        deleteReceiptPort.deleteReceiptList(user, receiptIds);
+        List<Receipt> receiptList = deleteReceiptPort.deleteReceiptList(user, receiptIds);
+        List<String> receiptImage = receiptEditor.deleteReceiptImage(receiptList);
+        deleteReceiptImagePort.deleteImages(receiptImage);
     }
 }

--- a/src/main/java/com/ClubAccount_BE/receipt/application/service/DeleteReceiptService.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/application/service/DeleteReceiptService.java
@@ -1,0 +1,22 @@
+package com.ClubAccount_BE.receipt.application.service;
+
+import com.ClubAccount_BE.receipt.application.port.in.DeleteReceiptUseCase;
+import com.ClubAccount_BE.receipt.application.port.out.DeleteReceiptPort;
+import com.ClubAccount_BE.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteReceiptService implements DeleteReceiptUseCase {
+
+    private final DeleteReceiptPort deleteReceiptPort;
+
+    @Override
+    public void deleteReceiptList(User user, List<Long> receiptIds) {
+        deleteReceiptPort.deleteReceiptList(user, receiptIds);
+    }
+}

--- a/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
+++ b/src/main/java/com/ClubAccount_BE/receipt/domain/service/ReceiptEditor.java
@@ -1,5 +1,6 @@
 package com.ClubAccount_BE.receipt.domain.service;
 
+import static com.ClubAccount_BE.core.constant.CommonConstant.DEFAULT_IMAGE;
 import static com.ClubAccount_BE.receipt.domain.type.ReceiptCategory.GROUP_DINING;
 import static com.ClubAccount_BE.receipt.domain.type.ReceiptCategory.OTHER;
 import static com.ClubAccount_BE.receipt.domain.type.ReceiptCategory.SUBSCRIPTION;
@@ -71,5 +72,15 @@ public class ReceiptEditor {
                         month,
                         monthlyExpense.getOrDefault(month, BigDecimal.ZERO)))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 영수증 이미지 삭제 시 필요한 URL 리스트 생성
+     */
+    public List<String> deleteReceiptImage(List<Receipt> receiptList) {
+        return receiptList.stream()
+                .map(Receipt::getReceiptImageUrl)
+                .filter(url -> url != null && !url.equals(DEFAULT_IMAGE))
+                .toList();
     }
 }

--- a/src/test/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptServiceTest.java
+++ b/src/test/java/com/ClubAccount_BE/receipt/application/service/CreateReceiptServiceTest.java
@@ -1,7 +1,7 @@
 package com.ClubAccount_BE.receipt.application.service;
 
 import com.ClubAccount_BE.receipt.application.port.out.CreateReceiptPort;
-import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptPort;
+import com.ClubAccount_BE.receipt.application.port.out.UploadReceiptImagePort;
 import com.ClubAccount_BE.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +16,7 @@ class CreateReceiptServiceTest {
     private CreateReceiptPort createReceiptPort;
 
     @Mock
-    private UploadReceiptPort uploadReceiptPort;
+    private UploadReceiptImagePort uploadReceiptImagePort;
 
     @InjectMocks
     private CreateReceiptService createReceiptService;


### PR DESCRIPTION
## 📌 작업 개요
* DB에 등록된 영수증 삭제와 S3 버킷에 등록된 객체를 삭제하는 기능 구현

---

## ✅ 작업 내용
1. 삭제할 영수증 ID를 찾아 영수증 삭제
2. 관리자가 등록하지 않은 영수증에 대해 삭제할 경우, 예외 처리 로직 추가
3. 삭제된 영수증의 이미지가 S3에 객체로 등록된 경우, S3 객체 삭제
4. 스웨거 문서 @LoginUser 파라미터 숨김 처리
5. Port 역할을 가지고 있는 클래스에 대한 명확한 클래스 네이밍 지정

---


## 📂 리뷰 요구사항
- Receipt가 삭제되었을 때, ReceiptItem도 삭제가 되도록 `orphanRemoval = true`로 정의가 되어 있습니다. 여러 개의 영수증 객체를 삭제해야 하기에 `deleteAllByIdInBatch`로 처리하고자 하였으나 영속성 컨텍스트의 상태와 동기화 문제가 생길 수 있기에 개별적으로 삭제를 처리하는 로직으로 구현했습니다.
- 추후에 영수증 삭제에 대한 로직에 대해 비동기 처리를 추가할 예정입니다.
- 현재 회원 이미지 등록과 영수증 이미지 등록에 대한 어댑터의 로직에 대해 중복이 발생하고 있어 이에 대한 논의가 필요할 것 같습니다.

---

